### PR TITLE
Fix #202: Display uncaught errors with more detail

### DIFF
--- a/core/test-output-stream.ts
+++ b/core/test-output-stream.ts
@@ -71,7 +71,7 @@ export class TestOutputStream extends ReadableStream {
 
       // if it's a match error then log it properly, otherwise log it as unhandled
       if (error instanceof MatchError) {
-          this._writeMatchErrorOutput(<MatchError>error);
+          this._writeMatchErrorOutput(error);
       } else {
           this._writeUnhandledErrorOutput(error);
       }

--- a/core/test-output-stream.ts
+++ b/core/test-output-stream.ts
@@ -69,11 +69,13 @@ export class TestOutputStream extends ReadableStream {
 
       this._writeOut(`not ok ${testId} ${description}\n`);
 
-      if (error instanceof MatchError === false) {
-         error = new MatchError("the test threw an error", "the test to run", "Test threw " + (<any>error.constructor).name + " with message \"" + error.message + "\"");
-      }
+      if (error instanceof MatchError) {
+          this._writeMatchErrorOutput(<MatchError>error);
 
-      this._writeOut(this._getErrorYaml(<MatchError>error));
+          //error = new MatchError("the test threw an error", "the test to run", "Test threw " + (<any>error.constructor).name + " with message \"" + error.message + "\"");
+      } else {
+          this._writeUnhandledErrorOutput(error);
+      }
    }
 
    private _getTestDescription(test: ITest, testCaseArguments: Array<any>): string {
@@ -106,12 +108,40 @@ export class TestOutputStream extends ReadableStream {
       return "undefined";
    }
 
-   private _getErrorYaml(error: MatchError): string {
-      return " ---\n" +
-      "   message: \"" + error.message.replace(/\\/g, "\\\\").replace(/"/g, "\\\"") + "\"\n" +
-      "   severity: fail\n" +
-      "   data:\n" +
-      "     got: " + JSON.stringify(error.actualValue) + "\n" +
-      "     expect: " + JSON.stringify(error.expectedValue) + "\n ...\n";
+   private _writeMatchErrorOutput(error: MatchError): void {
+
+       let sanitisedMessage = error.message.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+       let sanitisedActual = JSON.stringify(error.actualValue);
+       let sanitisedExpected = JSON.stringify(error.expectedValue);
+
+       this._writeFailure(sanitisedMessage, sanitisedActual, sanitisedExpected);
+
    }
+
+   private _writeUnhandledErrorOutput(error: Error): void {
+
+       this._writeFailure("The test threw an unhandled error.", "an unhandled error", "no unhandled errors to be thrown", error.stack);
+
+   }
+
+   private _writeFailure(message: string, actual: string, expected: string, stack?: string): void {
+
+       let output =
+           " ---\n" +
+           "   message: \"" + message + "\"\n" +
+           "   severity: fail\n" +
+           "   data:\n" +
+           "     got: " + actual + "\n" +
+           "     expect: " + expected + "\n";
+
+       if (stack) {
+           // encode the stack trace with base64 to prevent new lines from messing with the YAML
+           output = output + "     stack: " + new Buffer(stack).toString('base64') + "\n";
+       }
+
+       output = output + " ...\n";
+
+       this._writeOut(output);
+   }
+
 }

--- a/core/test-output-stream.ts
+++ b/core/test-output-stream.ts
@@ -134,8 +134,9 @@ export class TestOutputStream extends ReadableStream {
            "     expect: " + expected + "\n";
 
        if (stack) {
-           // encode the stack trace with base64 to prevent new lines from messing with the YAML
-           output = output + "     stack_base64: " + new Buffer(stack).toString("base64") + "\n";
+           output = output + "     stack: |\n";
+
+           output = output + stack.split("\n").map(l => "       " + l).join("\n") + "\n";
        }
 
        output = output + " ...\n";

--- a/core/test-output-stream.ts
+++ b/core/test-output-stream.ts
@@ -136,7 +136,7 @@ export class TestOutputStream extends ReadableStream {
 
        if (stack) {
            // encode the stack trace with base64 to prevent new lines from messing with the YAML
-           output = output + "     stack: " + new Buffer(stack).toString('base64') + "\n";
+           output = output + "     stack_base64: " + new Buffer(stack).toString('base64') + "\n";
        }
 
        output = output + " ...\n";

--- a/core/test-output-stream.ts
+++ b/core/test-output-stream.ts
@@ -69,10 +69,9 @@ export class TestOutputStream extends ReadableStream {
 
       this._writeOut(`not ok ${testId} ${description}\n`);
 
+      // if it's a match error then log it properly, otherwise log it as unhandled
       if (error instanceof MatchError) {
           this._writeMatchErrorOutput(<MatchError>error);
-
-          //error = new MatchError("the test threw an error", "the test to run", "Test threw " + (<any>error.constructor).name + " with message \"" + error.message + "\"");
       } else {
           this._writeUnhandledErrorOutput(error);
       }
@@ -136,7 +135,7 @@ export class TestOutputStream extends ReadableStream {
 
        if (stack) {
            // encode the stack trace with base64 to prevent new lines from messing with the YAML
-           output = output + "     stack_base64: " + new Buffer(stack).toString('base64') + "\n";
+           output = output + "     stack_base64: " + new Buffer(stack).toString("base64") + "\n";
        }
 
        output = output + " ...\n";

--- a/test/unit-tests/test-output-stream/emit-result.spec.ts
+++ b/test/unit-tests/test-output-stream/emit-result.spec.ts
@@ -15,7 +15,8 @@ const _getUnhandledErrorMessage: (stack: string) => string = (stack: string) => 
         "   data:\n" +
         "     got: an unhandled error\n" +
         "     expect: no unhandled errors to be thrown\n" +
-        "     stack_base64: " + new Buffer(stack).toString("base64") + "\n" +
+        "     stack: |\n" +
+        stack.split("\n").map(l => "       " + l).join("\n") + "\n" +
         " ...\n"
     );
 };

--- a/test/unit-tests/test-output-stream/emit-result.spec.ts
+++ b/test/unit-tests/test-output-stream/emit-result.spec.ts
@@ -15,7 +15,7 @@ const _getUnhandledErrorMessage: (stack: string) => string = (stack: string) => 
         "   data:\n" +
         "     got: an unhandled error\n" +
         "     expect: no unhandled errors to be thrown\n" +
-        "     stack_base64: " + new Buffer(stack).toString('base64') + "\n" +
+        "     stack_base64: " + new Buffer(stack).toString("base64") + "\n" +
         " ...\n"
     );
 };

--- a/test/unit-tests/test-output-stream/emit-result.spec.ts
+++ b/test/unit-tests/test-output-stream/emit-result.spec.ts
@@ -15,7 +15,7 @@ const _getUnhandledErrorMessage: (stack: string) => string = (stack: string) => 
         "   data:\n" +
         "     got: an unhandled error\n" +
         "     expect: no unhandled errors to be thrown\n" +
-        "     stack: " + new Buffer(stack).toString('base64') + "\n" +
+        "     stack_base64: " + new Buffer(stack).toString('base64') + "\n" +
         " ...\n"
     );
 };
@@ -235,7 +235,6 @@ export class EmitResultTests {
       Expect(() => testOutput.emitResult(1, testCaseResult)).toThrowError(TypeError, `Invalid test outcome: ${testOutcome}`);
    }
 
-   @FocusTest
    @TestCase("line 1\nline3\nline 7")
    @TestCase("function foo in a.ts\nfunction bar in z.ts\nfunction x in entry.ts")
    public shouldEmitCorrectUnhandledErrorStack(stack: string) {


### PR DESCRIPTION
<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

# Description

Display unhandled errors with more detail.

As discussed the stack trace is base64 encoded to prevent any newlines from being messing with the YAML (as a stack trace is very newline heavy)

<!-- Now, we've created a handy checklist before submitting your pull request to ensure it goes smoothly
      (we checked the first one for you because we know it's true) -->

# Checklist

- [x] I am an awesome developer and proud of my code
- [x] I added / updated / removed relevant unit or integration tests to prove my change works
- [x] I ran all tests using ```npm test``` to make sure everything else still works
- [x] I ran ```npm run review``` to ensure the code adheres to the repository standards

<!-- Thanks again, and if you'd like to add any further information you can do so below -->

# Additional Information
