### PR TITLE
Add toBeEmpty functionality

### DIFF
--- a/core/errors/empty-match-error.ts
+++ b/core/errors/empty-match-error.ts
@@ -1,0 +1,15 @@
+import { ArgumentStringifier } from "../stringification";
+import { MatchError } from "./match-error";
+
+export class EmptyMatchError extends MatchError {
+
+   public constructor(actualValue: any, shouldMatch: boolean) {
+      super();
+
+      const value = new ArgumentStringifier().stringify(actualValue);
+
+      this.message = `Expected "${value}" ${shouldMatch ? "to be" : "not to be"} empty.`;
+
+      this._actual = actualValue;
+   }
+}

--- a/core/errors/empty-match-error.ts
+++ b/core/errors/empty-match-error.ts
@@ -6,7 +6,7 @@ export class EmptyMatchError extends MatchError {
    public constructor(actualValue: any, shouldMatch: boolean) {
       super();
 
-      const value = new ArgumentStringifier().stringify(actualValue);
+      const value = (typeof actualValue === "string") ? actualValue : new ArgumentStringifier().stringify(actualValue);
 
       this.message = `Expected "${value}" ${shouldMatch ? "to be" : "not to be"} empty.`;
 

--- a/core/errors/function-call-count-match-error.ts
+++ b/core/errors/function-call-count-match-error.ts
@@ -29,7 +29,7 @@ export class FunctionCallCountMatchError extends MatchError {
 
   private static _buildActualValue(actualValue: FunctionSpy, args?: Array<any>) {
     return `function was called` +
-    `${args && actualValue.calls.length ? " with " + 
+    `${args && actualValue.calls.length ? " with " +
     actualValue.calls.map(call => JSON.stringify(call.args)).join(", ") : ""} `
     + `${actualValue.calls.length} time${actualValue.calls.length === 1 ? "" : "s"}.`;
   }

--- a/core/errors/index.ts
+++ b/core/errors/index.ts
@@ -1,4 +1,5 @@
 import { ContentsMatchError } from "./contents-match-error";
+import { EmptyMatchError } from "./empty-match-error";
 import { EqualMatchError } from "./equal-match-error";
 import { ErrorMatchError } from "./error-match-error";
 import { ExactMatchError } from "./exact-match-error";
@@ -25,5 +26,6 @@ export {
     FunctionCallMatchError,
     FunctionCallCountMatchError,
     TestTimeoutError,
-    PropertySetMatchError
+    PropertySetMatchError,
+    EmptyMatchError
 };

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -192,11 +192,7 @@ export class Matcher {
          throw new TypeError("toBeEmpty requires value passed in to Expect not to be null or undefined");
       }
 
-      if (typeof this.actualValue === "string") {
-         if ((this.actualValue.length === 0) !== this.shouldMatch) {
-            throw new EmptyMatchError(this.actualValue, this.shouldMatch);
-         }
-      } else if (Array.isArray(this.actualValue)) {
+      if (typeof this.actualValue === "string" || Array.isArray(this.actualValue)) {
          if ((this.actualValue.length === 0) !== this.shouldMatch) {
             throw new EmptyMatchError(this.actualValue, this.shouldMatch);
          }

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -1,5 +1,6 @@
 import {
    ContentsMatchError,
+   EmptyMatchError,
    EqualMatchError,
    ErrorMatchError,
    ExactMatchError,
@@ -180,6 +181,19 @@ export class Matcher {
 
       if (this._actualValue > lowerLimit !== this.shouldMatch) {
          throw new GreaterThanMatchError(this._actualValue, lowerLimit, this.shouldMatch);
+      }
+   }
+
+   /**
+    * Checks that an array is empty
+    */
+   public toBeEmpty() {
+      if (!Array.isArray(this._actualValue)) {
+         throw new TypeError("toBeEmpty requires value passed in to Expect to be an array");
+      }
+
+      if ((this.actualValue.length === 0) !== this.shouldMatch) {
+         throw new EmptyMatchError(this._actualValue, this.shouldMatch);
       }
    }
 

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -185,15 +185,27 @@ export class Matcher {
    }
 
    /**
-    * Checks that an array is empty
+    * Checks that an array is empty, a string is empty, or an object literal has no properties
     */
    public toBeEmpty() {
-      if (!Array.isArray(this._actualValue)) {
-         throw new TypeError("toBeEmpty requires value passed in to Expect to be an array");
+      if (null === this.actualValue || undefined === this.actualValue) {
+         throw new TypeError("toBeEmpty requires value passed in to Expect not to be null or undefined");
       }
 
-      if ((this.actualValue.length === 0) !== this.shouldMatch) {
-         throw new EmptyMatchError(this._actualValue, this.shouldMatch);
+      if (typeof this.actualValue === "string") {
+         if ((this.actualValue.length === 0) !== this.shouldMatch) {
+            throw new EmptyMatchError(this.actualValue, this.shouldMatch);
+         }
+      } else if (Array.isArray(this.actualValue)) {
+         if ((this.actualValue.length === 0) !== this.shouldMatch) {
+            throw new EmptyMatchError(this.actualValue, this.shouldMatch);
+         }
+      } else if (this.actualValue.constructor === Object) {
+         if ((Object.keys(this.actualValue).length === 0) !== this.shouldMatch) {
+            throw new EmptyMatchError(this.actualValue, this.shouldMatch);
+         }
+      } else {
+         throw new TypeError("toBeEmpty requires value passed in to Expect to be an array, string or object literal");
       }
    }
 

--- a/core/test-loader.ts
+++ b/core/test-loader.ts
@@ -34,9 +34,9 @@ export class TestLoader {
    }
 
    private _loadTestFixture(testFixtureConstructor: any, defaultFixtureDescription: string): ITestFixture {
-      // get test fixture metadata or create new metadata 
-      // to support not requiring the TestFixture decorator. 
-      // This functionality will be removed in 2.0.0 where 
+      // get test fixture metadata or create new metadata
+      // to support not requiring the TestFixture decorator.
+      // This functionality will be removed in 2.0.0 where
       // TestFixture decorator will become mandatory
       const testFixture = Reflect.getMetadata(METADATA_KEYS.TEST_FIXTURE, testFixtureConstructor)
                        || new TestFixture(defaultFixtureDescription);

--- a/core/test-output-stream.ts
+++ b/core/test-output-stream.ts
@@ -81,7 +81,7 @@ export class TestOutputStream extends ReadableStream {
       let testDescription = test.description;
 
       if (testCaseArguments !== undefined && testCaseArguments.length > 0) {
-         testDescription += ` [ ${testCaseArguments.map(argument => 
+         testDescription += ` [ ${testCaseArguments.map(argument =>
              this._getArgumentDescription(argument)
          ).join(", ")} ]`;
       }

--- a/test/integration-tests/gulp/gulpfile.ts
+++ b/test/integration-tests/gulp/gulpfile.ts
@@ -11,8 +11,8 @@ Gulp.task("test-expectations", (done: () => any) => {
     const testRunner = new TestRunner();
 
     testRunner.outputStream
-              // pipe to your favourite tap producer or not and just get TAP :) 
-              // .pipe(TapBark.create().getPipeable()) 
+              // pipe to your favourite tap producer or not and just get TAP :)
+              // .pipe(TapBark.create().getPipeable())
               .pipe(process.stdout);
 
     // run the test set
@@ -30,7 +30,7 @@ Gulp.task("test-syntax", (done: () => any) => {
 
     testRunner.outputStream
               // .pipe(TapBark.create().getPipeable())
-              // pipe to your favourite tap producer or not and just get TAP :) 
+              // pipe to your favourite tap producer or not and just get TAP :)
               .pipe(process.stdout);
 
     // run the test set

--- a/test/unit-tests/errors/empty-match-error.spec.ts
+++ b/test/unit-tests/errors/empty-match-error.spec.ts
@@ -1,0 +1,19 @@
+import { Expect, Test } from "../../../core/alsatian-core";
+import { EmptyMatchError } from "../../../core/errors/empty-match-error";
+
+export class EmptyMatchErrorTests {
+
+   @Test()
+   public shouldBeEmptyMessage() {
+      let error = new EmptyMatchError([], true);
+
+      Expect(error.message).toBe(`Expected "${JSON.stringify([])}" to be empty.`);
+   }
+
+   @Test()
+   public shouldNotBeEmptyMessage() {
+      let error = new EmptyMatchError([], false);
+
+      Expect(error.message).toBe(`Expected "${JSON.stringify([])}" not to be empty.`);
+   }
+}

--- a/test/unit-tests/errors/empty-match-error.spec.ts
+++ b/test/unit-tests/errors/empty-match-error.spec.ts
@@ -16,4 +16,11 @@ export class EmptyMatchErrorTests {
 
       Expect(error.message).toBe(`Expected "${JSON.stringify([])}" not to be empty.`);
    }
+
+   @Test()
+   public doesNotDoubleQuoteStrings() {
+      let error = new EmptyMatchError("something", false);
+
+      Expect(error.message).toBe(`Expected "something" not to be empty.`);
+   }
 }

--- a/test/unit-tests/expect-tests/to-be-empty.spec.ts
+++ b/test/unit-tests/expect-tests/to-be-empty.spec.ts
@@ -1,0 +1,66 @@
+import { Expect, Test, TestCase } from "../../../core/alsatian-core";
+import { EmptyMatchError } from "../../../core/errors/empty-match-error";
+
+export class ToBeEmptyTests {
+
+   @TestCase([])
+   @TestCase([1])
+   @TestCase([1, 2])
+   public emptyShouldNotThrowTypeErrorForArrays(value: any) {
+      let expect = Expect(value);
+
+      Expect(() => expect.toBeEmpty())
+         .not
+         .toThrowError(TypeError, "toBeEmpty requires value passed in to Expect to be an array");
+   }
+
+   @TestCase(null)
+   @TestCase(0)
+   @TestCase(42)
+   @TestCase(-42)
+   @TestCase("")
+   @TestCase("something")
+   @TestCase({})
+   @TestCase({ with: "something" })
+   @TestCase(undefined)
+   public emptyShouldThrowTypeErrorForNonArrays(value: any) {
+      let expect = Expect(value);
+
+      Expect(() => expect.toBeEmpty())
+         .toThrowError(TypeError, "toBeEmpty requires value passed in to Expect to be an array");
+   }
+
+   @Test()
+   public emptyShouldNotThrowErrorForEmptyArray() {
+      let expect = Expect([]);
+
+      Expect(() => expect.toBeEmpty())
+         .not
+         .toThrow();
+   }
+
+   @Test()
+   public emptyShouldThrowErrorForNonEmptyArray() {
+      let expect = Expect([0]);
+
+      Expect(() => expect.toBeEmpty())
+         .toThrowError(EmptyMatchError, "Expected \"[0]\" to be empty.");
+   }
+
+   @Test()
+   public notEmptyShouldThrowErrorForEmptyArray() {
+      let expect = Expect([]);
+
+      Expect(() => expect.not.toBeEmpty())
+         .toThrowError(EmptyMatchError, "Expected \"[]\" not to be empty.");
+   }
+
+   @Test()
+   public notEmptyShouldNotThrowErrorForNonEmptyArray() {
+      let expect = Expect([0]);
+
+      Expect(() => expect.not.toBeEmpty())
+         .not
+         .toThrow();
+   }
+}

--- a/test/unit-tests/expect-tests/to-be-empty.spec.ts
+++ b/test/unit-tests/expect-tests/to-be-empty.spec.ts
@@ -1,38 +1,70 @@
 import { Expect, Test, TestCase } from "../../../core/alsatian-core";
 import { EmptyMatchError } from "../../../core/errors/empty-match-error";
 
+class DummyClass { }
+
 export class ToBeEmptyTests {
+
+   private readonly _typeErrorMessage: string =
+      "toBeEmpty requires value passed in to Expect to be an array, string or object literal";
 
    @TestCase([])
    @TestCase([1])
    @TestCase([1, 2])
    public emptyShouldNotThrowTypeErrorForArrays(value: any) {
-      let expect = Expect(value);
+      const expect = Expect(value);
 
       Expect(() => expect.toBeEmpty())
          .not
-         .toThrowError(TypeError, "toBeEmpty requires value passed in to Expect to be an array");
+         .toThrowError(TypeError, this._typeErrorMessage);
+   }
+
+   @TestCase("")
+   @TestCase("string")
+   public emptyShouldNotThrowTypeErrorForStrings(value: any) {
+      const expect = Expect(value);
+
+      Expect(() => expect.toBeEmpty())
+         .not
+         .toThrowError(TypeError, this._typeErrorMessage);
+   }
+
+   @TestCase({})
+   @TestCase({ a: true })
+   public emptyShouldNotThrowTypeErrorForObjectLiterals(value: any) {
+      const expect = Expect(value);
+
+      Expect(() => expect.toBeEmpty())
+         .not
+         .toThrowError(TypeError, this._typeErrorMessage);
    }
 
    @TestCase(null)
+   @TestCase(undefined)
+   public emptyShouldThrowTypeErrorForNullTypes(value: any) {
+      const expect = Expect(value);
+
+      Expect(() => expect.toBeEmpty())
+         .toThrowError(TypeError, "toBeEmpty requires value passed in to Expect not to be null or undefined");
+   }
+
    @TestCase(0)
    @TestCase(42)
    @TestCase(-42)
-   @TestCase("")
-   @TestCase("something")
-   @TestCase({})
-   @TestCase({ with: "something" })
-   @TestCase(undefined)
-   public emptyShouldThrowTypeErrorForNonArrays(value: any) {
-      let expect = Expect(value);
+   @TestCase(true)
+   @TestCase(new Date())
+   @TestCase(new Error())
+   @TestCase(new DummyClass())
+   public emptyShouldThrowTypeErrorForInvalidTypes(value: any) {
+      const expect = Expect(value);
 
       Expect(() => expect.toBeEmpty())
-         .toThrowError(TypeError, "toBeEmpty requires value passed in to Expect to be an array");
+         .toThrowError(TypeError, this._typeErrorMessage);
    }
 
    @Test()
    public emptyShouldNotThrowErrorForEmptyArray() {
-      let expect = Expect([]);
+      const expect = Expect([]);
 
       Expect(() => expect.toBeEmpty())
          .not
@@ -41,7 +73,7 @@ export class ToBeEmptyTests {
 
    @Test()
    public emptyShouldThrowErrorForNonEmptyArray() {
-      let expect = Expect([0]);
+      const expect = Expect([0]);
 
       Expect(() => expect.toBeEmpty())
          .toThrowError(EmptyMatchError, "Expected \"[0]\" to be empty.");
@@ -49,7 +81,7 @@ export class ToBeEmptyTests {
 
    @Test()
    public notEmptyShouldThrowErrorForEmptyArray() {
-      let expect = Expect([]);
+      const expect = Expect([]);
 
       Expect(() => expect.not.toBeEmpty())
          .toThrowError(EmptyMatchError, "Expected \"[]\" not to be empty.");
@@ -57,7 +89,75 @@ export class ToBeEmptyTests {
 
    @Test()
    public notEmptyShouldNotThrowErrorForNonEmptyArray() {
-      let expect = Expect([0]);
+      const expect = Expect([0]);
+
+      Expect(() => expect.not.toBeEmpty())
+         .not
+         .toThrow();
+   }
+
+   @Test()
+   public emptyShouldNotThrowErrorForEmptyString() {
+      const expect = Expect("");
+
+      Expect(() => expect.toBeEmpty())
+         .not
+         .toThrow();
+   }
+
+   @Test()
+   public emptyShouldThrowErrorForNonEmptyString() {
+      const expect = Expect("string");
+
+      Expect(() => expect.toBeEmpty())
+         .toThrowError(EmptyMatchError, "Expected \"string\" to be empty.");
+   }
+
+   @Test()
+   public notEmptyShouldThrowErrorForEmptyString() {
+      const expect = Expect("");
+
+      Expect(() => expect.not.toBeEmpty())
+         .toThrowError(EmptyMatchError, "Expected \"\" not to be empty.");
+   }
+
+   @Test()
+   public notEmptyShouldNotThrowErrorForNonEmptyString() {
+      const expect = Expect("string");
+
+      Expect(() => expect.not.toBeEmpty())
+         .not
+         .toThrow();
+   }
+
+   @Test()
+   public emptyShouldNotThrowErrorForEmptyObject() {
+      const expect = Expect({});
+
+      Expect(() => expect.toBeEmpty())
+         .not
+         .toThrow();
+   }
+
+   @Test()
+   public emptyShouldThrowErrorForNonEmptyObject() {
+      const expect = Expect({ a: true });
+
+      Expect(() => expect.toBeEmpty())
+         .toThrowError(EmptyMatchError, "Expected \"{\"a\":true}\" to be empty.");
+   }
+
+   @Test()
+   public notEmptyShouldThrowErrorForEmptyObject() {
+      const expect = Expect({});
+
+      Expect(() => expect.not.toBeEmpty())
+         .toThrowError(EmptyMatchError, "Expected \"{}\" not to be empty.");
+   }
+
+   @Test()
+   public notEmptyShouldNotThrowErrorForNonEmptyObject() {
+      const expect = Expect({ a: true });
 
       Expect(() => expect.not.toBeEmpty())
          .not


### PR DESCRIPTION
# Description

https://github.com/alsatian-test/alsatian/issues/293

Adding in an toBeEmpty expectation for array types, which will fail if the actual value is an empty array (or if it's not when prefixed with the `.not` operator)

# Checklist

- [x] I am an awesome developer and proud of my code
- [x] I added / updated / removed relevant unit or integration tests to prove my change works
- [x] I ran all tests using ```npm test``` to make sure everything else still works
- [x] I ran ```npm run review``` to ensure the code adheres to the repository standards
