### PR TITLE
Hack: Add notifications to to throw async

### DIFF
--- a/core/expect.ts
+++ b/core/expect.ts
@@ -231,7 +231,7 @@ export class Matcher {
    /**
     * Checks that a function throws an error asynchronously when executed
     */
-   public async toThrowAsync() {
+   public async toThrowAsync(): Promise<void> {
 
       if (this._actualValue instanceof Function === false) {
          throw new TypeError("toThrow requires value passed in to Expect to be a function.");
@@ -249,6 +249,7 @@ export class Matcher {
       if (errorThrown === undefined === this.shouldMatch) {
          throw new ErrorMatchError(errorThrown, this.shouldMatch);
       }
+      return Promise.resolve();
    }
 
    /**

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -27,7 +27,7 @@ import {
 /**
  * Messages
  */
-export interface Messages {
+export interface Notifications {
     onErr?: Function;
     onOk?: Function;
 }
@@ -239,9 +239,7 @@ export class Matcher {
    /**
     * Checks that a function throws an error asynchronously when executed
     */
-   public async toThrowAsync(messages?: Messages): Promise<void> {
-      if (messages && messages.onOk) messages.onOk();
-
+   public async toThrowAsync(notify?: Notifications): Promise<void> {
       if (this._actualValue instanceof Function === false) {
          throw new TypeError("toThrowAsync requires value passed in to Expect to be a function.");
       }
@@ -256,8 +254,14 @@ export class Matcher {
       }
 
       if (errorThrown === undefined === this.shouldMatch) {
-         if (messages && messages.onErr) messages.onErr();
+         if (notify && notify.onErr) {
+            notify.onErr();
+         }
          throw new ErrorMatchError(errorThrown, this.shouldMatch);
+      } else {
+         if (notify && notify.onOk) {
+            notify.onOk();
+         }
       }
       return Promise.resolve();
    }

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -28,8 +28,8 @@ import {
  * Messages
  */
 export interface Messages {
-    onErr?: string;
-    onOk?: string;
+    onErr?: Function;
+    onOk?: Function;
 }
 
 /**
@@ -240,7 +240,7 @@ export class Matcher {
     * Checks that a function throws an error asynchronously when executed
     */
    public async toThrowAsync(messages?: Messages): Promise<void> {
-      if (messages && messages.onOk) console.log(messages.onOk);
+      if (messages && messages.onOk) messages.onOk();
 
       if (this._actualValue instanceof Function === false) {
          throw new TypeError("toThrowAsync requires value passed in to Expect to be a function.");
@@ -256,7 +256,7 @@ export class Matcher {
       }
 
       if (errorThrown === undefined === this.shouldMatch) {
-         if (messages && messages.onErr) console.log(messages.onErr);
+         if (messages && messages.onErr) messages.onErr();
          throw new ErrorMatchError(errorThrown, this.shouldMatch);
       }
       return Promise.resolve();

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -229,6 +229,29 @@ export class Matcher {
    }
 
    /**
+    * Checks that a function throws an error asynchronously when executed
+    */
+   public async toThrowAsync() {
+
+      if (this._actualValue instanceof Function === false) {
+         throw new TypeError("toThrow requires value passed in to Expect to be a function.");
+      }
+
+      let errorThrown: Error;
+
+      try {
+         await this._actualValue();
+      }
+      catch (error) {
+         errorThrown = error;
+      }
+
+      if (errorThrown === undefined === this.shouldMatch) {
+         throw new ErrorMatchError(errorThrown, this.shouldMatch);
+      }
+   }
+
+   /**
     * Checks that a function throws a specific error
     * @param errorType - the type of error that should be thrown
     * @param errorMessage - the message that the error should have

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -25,6 +25,14 @@ import {
 } from "./matchers";
 
 /**
+ * Messages
+ */
+export interface Messages {
+    onErr?: string;
+    onOk?: string;
+}
+
+/**
  * Allows checking of test outcomes
  * @param actualValue - the value or function under test
  */
@@ -231,10 +239,11 @@ export class Matcher {
    /**
     * Checks that a function throws an error asynchronously when executed
     */
-   public async toThrowAsync(): Promise<void> {
+   public async toThrowAsync(messages?: Messages): Promise<void> {
+      if (messages && messages.onOk) console.log(messages.onOk);
 
       if (this._actualValue instanceof Function === false) {
-         throw new TypeError("toThrow requires value passed in to Expect to be a function.");
+         throw new TypeError("toThrowAsync requires value passed in to Expect to be a function.");
       }
 
       let errorThrown: Error;
@@ -247,6 +256,7 @@ export class Matcher {
       }
 
       if (errorThrown === undefined === this.shouldMatch) {
+         if (messages && messages.onErr) console.log(messages.onErr);
          throw new ErrorMatchError(errorThrown, this.shouldMatch);
       }
       return Promise.resolve();

--- a/test/unit-tests/expect-tests/to-throw.spec.ts
+++ b/test/unit-tests/expect-tests/to-throw.spec.ts
@@ -1,4 +1,4 @@
-import { Expect, Test, TestCase } from "../../../core/alsatian-core";
+import { AsyncTest, Expect, Test, TestCase } from "../../../core/alsatian-core";
 import { ErrorMatchError } from "../../../core/errors/error-match-error";
 
 export class ToThrowTests {
@@ -149,5 +149,33 @@ export class ToThrowTests {
       Expect(errorMatchError).toBeDefined();
       Expect(errorMatchError).not.toBeNull();
       Expect(errorMatchError.expected).toBe("error not to be thrown.");
+   }
+
+   // Asynchronous throw
+   private async asyncThrowError(delayMs: number): Promise<void> {
+      return new Promise<void>((_, reject) => {
+         setTimeout(reject(new Error("Timeout then reject")), delayMs);
+      });
+   }
+
+   // Asynchronous non-throw
+   private async asyncNonThrowError(delayMs: number): Promise<void> {
+      return new Promise<void>((resolve) => {
+         setTimeout(resolve(), delayMs);
+      });
+   }
+
+   @TestCase(0)
+   @TestCase(100)
+   @AsyncTest("Test toThrowAsyncShouldThrow")
+   public async testToThrowAsyncShouldThrow(delayMs: number) {
+      Expect(async () => this.asyncThrowError(delayMs)).toThrowAsync();
+   }
+
+   @TestCase(0)
+   @TestCase(100)
+   @AsyncTest("Test toThrowAsync")
+   public async testToThrowAsyncShouldNotThrow(delayMs: number) {
+      Expect(async () => this.asyncNonThrowError(delayMs)).not.toThrowAsync();
    }
 }

--- a/test/unit-tests/expect-tests/to-throw.spec.ts
+++ b/test/unit-tests/expect-tests/to-throw.spec.ts
@@ -169,13 +169,42 @@ export class ToThrowTests {
    @TestCase(100)
    @AsyncTest("Test toThrowAsyncShouldThrow")
    public async testToThrowAsyncShouldThrow(delayMs: number) {
-      Expect(async () => this.asyncThrowError(delayMs)).toThrowAsync();
+      await Expect(async () => this.asyncThrowError(delayMs)).toThrowAsync();
    }
 
    @TestCase(0)
    @TestCase(100)
    @AsyncTest("Test toThrowAsync")
    public async testToThrowAsyncShouldNotThrow(delayMs: number) {
-      Expect(async () => this.asyncNonThrowError(delayMs)).not.toThrowAsync();
+      await Expect(async () => this.asyncNonThrowError(delayMs)).not.toThrowAsync();
+   }
+
+   @TestCase(0)
+   @TestCase(100)
+   @AsyncTest("Test toThrowAsync onOk notification")
+   public async testToThrowAsyncNotifyOnOk(delayMs: number) {
+      let onErrNotified, onOkNotified: boolean;
+      await Expect(async () => this.asyncThrowError(delayMs)).toThrowAsync({
+         onErr: () => onErrNotified = true,
+         onOk: () => onOkNotified = true
+      });
+      Expect(onErrNotified).not.toBeDefined();
+      Expect(onOkNotified).toBeTruthy();
+   }
+
+   @TestCase(0)
+   @TestCase(100)
+   @AsyncTest("Test toThrowAsync onErr notification")
+   public async testToThrowAsyncNotifyOnErr(delayMs: number) {
+      let onErrNotified, onOkNotified: boolean;
+      try {
+         await Expect(async () => this.asyncThrowError(delayMs)).not.toThrowAsync({
+            onErr: () => onErrNotified = true,
+            onOk: () => onOkNotified = true
+         });
+      } catch (err) {
+      }
+      Expect(onErrNotified).toBeTruthy();
+      Expect(onOkNotified).not.toBeDefined();
    }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
       "preserveConstEnums": true,
       "experimentalDecorators": true,
       "emitDecoratorMetadata": true,
-      "lib": [ "es2015" ]
+      "lib": [ "DOM", "es2015" ]
    },
    "buildOnSave": false,
    "compileOnSave": true,


### PR DESCRIPTION
Another hack, I've added a `interface Notifications` so that the `spec` can do something on success for failure. That something for me was outputting some debug see [this](https://github.com/winksaville/test-clang-and-wasm-merge/blob/master/utils/utils.spec.ts).

One possible enhancement would be to have the onErr/onOk return a boolean and control if the matcher should succeed or fail. I'm guessing SpyOn can maybe do all of this, but this seemed to be simple and adding an optional parameter to the matchers is a non-breaking change.

Just a thought.