### PR TITLE
Enhance error reporting with line number

### DIFF
--- a/core/errors/index.ts
+++ b/core/errors/index.ts
@@ -3,7 +3,6 @@ import { EmptyMatchError } from "./empty-match-error";
 import { EqualMatchError } from "./equal-match-error";
 import { ErrorMatchError } from "./error-match-error";
 import { ExactMatchError } from "./exact-match-error";
-import { TypeMatchError } from "./type-match-error";
 import { FunctionCallCountMatchError } from "./function-call-count-match-error";
 import { FunctionCallMatchError } from "./function-call-match-error";
 import { GreaterThanMatchError } from "./greater-than-match-error";
@@ -13,6 +12,7 @@ import { PropertySetMatchError } from "./property-set-match-error";
 import { RegexMatchError } from "./regex-match-error";
 import { TestTimeoutError } from "./test-timeout-error";
 import { TruthyMatchError } from "./truthy-match-error";
+import { TypeMatchError } from "./type-match-error";
 
 export {
     MatchError,

--- a/core/errors/index.ts
+++ b/core/errors/index.ts
@@ -3,6 +3,7 @@ import { EmptyMatchError } from "./empty-match-error";
 import { EqualMatchError } from "./equal-match-error";
 import { ErrorMatchError } from "./error-match-error";
 import { ExactMatchError } from "./exact-match-error";
+import { TypeMatchError } from "./type-match-error";
 import { FunctionCallCountMatchError } from "./function-call-count-match-error";
 import { FunctionCallMatchError } from "./function-call-match-error";
 import { GreaterThanMatchError } from "./greater-than-match-error";
@@ -17,6 +18,7 @@ export {
     MatchError,
     ExactMatchError,
     EqualMatchError,
+    TypeMatchError,
     RegexMatchError,
     TruthyMatchError,
     ContentsMatchError,

--- a/core/errors/match-error.ts
+++ b/core/errors/match-error.ts
@@ -12,10 +12,37 @@ export class MatchError extends ExtendoError {
     return this._expected;
   }
 
+  protected _fileName: string;
+  public get fileName(): string {
+    return this._fileName;
+  }
+  public set fileName(v: string) {
+    this._fileName = v;
+  }
+
+  protected _lineNumber: number;
+  public get lineNumber(): number {
+    return this._lineNumber;
+  }
+  public set lineNumber(v: number) {
+    this._lineNumber = v;
+  }
+
+  protected _columnNumber: number;
+  public get columnNumber(): number {
+    return this._columnNumber;
+  }
+  public set columnNumber(v: number) {
+    this._columnNumber = v;
+  }
+
   public constructor(message?: string, expectedValue?: any, actualValue?: any) {
     super(message);
 
     this._actual = actualValue;
     this._expected = expectedValue;
+    this._fileName = "";
+    this._lineNumber = -1;
+    this._columnNumber = -1;
   }
 }

--- a/core/errors/type-match-error.ts
+++ b/core/errors/type-match-error.ts
@@ -1,0 +1,8 @@
+import { MatchError } from "./match-error";
+
+export class TypeMatchError extends MatchError {
+
+  public constructor(message: any) {
+    super(message);
+  }
+}

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -231,7 +231,7 @@ export class Matcher {
    /**
     * Checks that a function throws an error asynchronously when executed
     */
-   public async toThrowAsync() {
+   public async toThrowAsync(): Promise<void> {
 
       if (this._actualValue instanceof Function === false) {
          throw new TypeError("toThrow requires value passed in to Expect to be a function.");
@@ -249,6 +249,7 @@ export class Matcher {
       if (errorThrown === undefined === this.shouldMatch) {
          throw new ErrorMatchError(errorThrown, this.shouldMatch);
       }
+      return Promise.resolve();
    }
 
    /**

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -1,5 +1,3 @@
-require("source-map-support").install
-
 import {
    ContentsMatchError,
    EmptyMatchError,
@@ -27,91 +25,10 @@ import {
    FunctionSpyMatcher
 } from "./matchers";
 
-
-export class TraceLocation {
-    public func: string;
-    public file: string;
-    public line: number;
-    public col:  number;
-
-    public constructor() {
-        this.file = "<no info>";
-        this.func = "<no info>";
-        this.line = -1;
-        this.col  = -1;
-    }
-
-    public toString(): string {
-        return `at ${this.func} (${this.file}:${this.line}:${this.col}`;
-    }
-}
-
-export class TraceMarker {
-    private _stackState: string;
-
-    /**
-     * Return the location of where this routine was called from
-     */
-    public static here(callDepth = 1): TraceLocation {
-        let tm = new TraceMarker();
-        return tm.mark(callDepth).getLocation();
-    }
-
-    /**
-     * Constructor
-     */
-    public constructor() {
-    }
-
-    /**
-     * Mark the "current" location.
-     *
-     * @param callDepth is the call nesting if used directly no
-     *        value is necessary and the default is 0. But if you
-     *        use TraceMarker.mark in a subroutine and you want to
-     *        mark where that subroutine was called from you need
-     *        callDepth = 1 or the approprate value.
-     */
-    public mark(callDepth: number = 0): TraceMarker {
-        let saveStackTraceLimit = Error.stackTraceLimit;
-        Error.stackTraceLimit = callDepth + 1;
-        let err = new Error();
-        Error.captureStackTrace(err, this.mark);
-        Error.stackTraceLimit = saveStackTraceLimit;
-        //console.log(`${err.stack}`);
-        this._stackState = err.stack;
-        return this;
-    }
-
-
-    /**
-     * Return the TraceLocation
-     *
-     */
-    public getLocation(): TraceLocation {
-        //console.log(`${this.stackState}`);
-        let stack = this._stackState.split("\n");
-        let location = new TraceLocation();
-        if (stack.length >= 2) {
-            //console.log(`stack[tos]=${stack[stack.length - 1]}`);
-            let r = /.*? at (.*?) \((.*?):(\d+):(\d+)\)/.exec(`${stack[stack.length - 1]}`);
-            //console.log(`r=${r}`);
-            if (r.length > 2) {
-                location.file = r[2];
-            }
-            if (r.length > 1) {
-                location.func = r[1];
-            }
-            if (r.length > 3) {
-                location.line = Number(r[3]);
-            }
-            if (r.length > 4) {
-                location.col = Number(r[4]);
-            }
-        }
-        return location;
-    }
-}
+import {
+   TraceLocation,
+   TraceMarker
+} from "./tracing";
 
 /**
  * Allows checking of test outcomes

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -1,3 +1,5 @@
+require("source-map-support").install
+
 import {
    ContentsMatchError,
    EmptyMatchError,
@@ -47,6 +49,15 @@ export class Matcher {
        return this._shouldMatch;
    }
 
+   private _throwError(err: Error) {
+      Error.captureStackTrace(err, this._throwError);
+      let stack = err.stack.split("\n");
+      if (stack.length >= 2) {
+          err.message = `${err.message} ${stack[1].trim().replace("at", "At")}`
+      }
+      throw err;
+   }
+
    public constructor(actualValue: any) {
       this._actualValue = actualValue;
    }
@@ -65,7 +76,7 @@ export class Matcher {
     */
    public toBe(expectedValue: any) {
       if (expectedValue !== this._actualValue === this.shouldMatch) {
-         throw new ExactMatchError(this._actualValue, expectedValue, this.shouldMatch);
+         this._throwError(new ExactMatchError(this._actualValue, expectedValue, this.shouldMatch));
       }
    }
 
@@ -79,7 +90,7 @@ export class Matcher {
 
          if (typeof expectedValue !== "object" ||
              this._checkObjectsAreDeepEqual(expectedValue, this._actualValue) !== this.shouldMatch) {
-            throw new EqualMatchError(this._actualValue, expectedValue, this.shouldMatch);
+            this._throwError(new EqualMatchError(this._actualValue, expectedValue, this.shouldMatch));
          }
       }
    }
@@ -90,15 +101,15 @@ export class Matcher {
     */
    public toMatch(regex: RegExp) {
       if (regex === null || regex === undefined) {
-         throw new TypeError("toMatch regular expression must not be null or undefined.");
+         this._throwError(new TypeError("toMatch regular expression must not be null or undefined."));
       }
 
       if (typeof this._actualValue !== "string") {
-         throw new TypeError("toMatch must only be used to match on strings.");
+         this._throwError(new TypeError("toMatch must only be used to match on strings."));
       }
 
       if (!regex.test(this._actualValue) === this.shouldMatch) {
-         throw new RegexMatchError(this._actualValue, regex, this.shouldMatch);
+         this._throwError(new RegexMatchError(this._actualValue, regex, this.shouldMatch));
       }
    }
 
@@ -107,7 +118,7 @@ export class Matcher {
     */
    public toBeDefined() {
       if (this._actualValue === undefined === this.shouldMatch) {
-         throw new ExactMatchError(this._actualValue, undefined, !this.shouldMatch);
+         this._throwError(new ExactMatchError(this._actualValue, undefined, !this.shouldMatch));
       }
    }
 
@@ -116,7 +127,7 @@ export class Matcher {
     */
    public toBeNull() {
       if (this._actualValue !== null === this.shouldMatch) {
-         throw new ExactMatchError(this._actualValue, null, this.shouldMatch);
+         this._throwError(new ExactMatchError(this._actualValue, null, this.shouldMatch));
       }
    }
 
@@ -125,7 +136,7 @@ export class Matcher {
     */
    public toBeTruthy() {
       if ((this._actualValue && !this.shouldMatch) || (!this._actualValue && this.shouldMatch)) {
-         throw new TruthyMatchError(this._actualValue, this.shouldMatch);
+         this._throwError(new TruthyMatchError(this._actualValue, this.shouldMatch));
       }
    }
 
@@ -136,15 +147,15 @@ export class Matcher {
    public toContain(expectedContent: any) {
 
       if (this._actualValue instanceof Array === false && typeof this._actualValue !== "string") {
-         throw new TypeError("toContain must only be used to check whether strings or arrays contain given contents.");
+         this._throwError(new TypeError("toContain must only be used to check whether strings or arrays contain given contents."));
       }
 
       if (typeof this._actualValue === "string" && typeof expectedContent !== "string") {
-         throw new TypeError("toContain cannot check whether a string contains a non string value.");
+         this._throwError(new TypeError("toContain cannot check whether a string contains a non string value."));
       }
 
       if (this._actualValue.indexOf(expectedContent) === -1 === this.shouldMatch) {
-         throw new ContentsMatchError(this._actualValue, expectedContent, this.shouldMatch);
+         this._throwError(new ContentsMatchError(this._actualValue, expectedContent, this.shouldMatch));
       }
    }
 
@@ -154,15 +165,15 @@ export class Matcher {
     */
    public toBeLessThan(upperLimit: number) {
       if (upperLimit === null || upperLimit === undefined) {
-         throw new TypeError("toBeLessThan upper limit must not be null or undefined.");
+         this._throwError(new TypeError("toBeLessThan upper limit must not be null or undefined."));
       }
 
       if (typeof this._actualValue !== "number") {
-         throw new TypeError("toBeLessThan can only check numbers.");
+         this._throwError(new TypeError("toBeLessThan can only check numbers."));
       }
 
       if (this._actualValue < upperLimit !== this.shouldMatch) {
-         throw new LessThanMatchError(this._actualValue, upperLimit, this.shouldMatch);
+         this._throwError(new LessThanMatchError(this._actualValue, upperLimit, this.shouldMatch));
       }
    }
 
@@ -172,15 +183,15 @@ export class Matcher {
     */
    public toBeGreaterThan(lowerLimit: number) {
       if (lowerLimit === null || lowerLimit === undefined) {
-         throw new TypeError("toBeGreaterThan lower limit must not be null or undefined.");
+         this._throwError(new TypeError("toBeGreaterThan lower limit must not be null or undefined."));
       }
 
       if (typeof this._actualValue !== "number") {
-         throw new TypeError("toBeGreaterThan can only check numbers.");
+         this._throwError(new TypeError("toBeGreaterThan can only check numbers."));
       }
 
       if (this._actualValue > lowerLimit !== this.shouldMatch) {
-         throw new GreaterThanMatchError(this._actualValue, lowerLimit, this.shouldMatch);
+         this._throwError(new GreaterThanMatchError(this._actualValue, lowerLimit, this.shouldMatch));
       }
    }
 
@@ -189,19 +200,19 @@ export class Matcher {
     */
    public toBeEmpty() {
       if (null === this.actualValue || undefined === this.actualValue) {
-         throw new TypeError("toBeEmpty requires value passed in to Expect not to be null or undefined");
+         this._throwError(new TypeError("toBeEmpty requires value passed in to Expect not to be null or undefined"));
       }
 
       if (typeof this.actualValue === "string" || Array.isArray(this.actualValue)) {
          if ((this.actualValue.length === 0) !== this.shouldMatch) {
-            throw new EmptyMatchError(this.actualValue, this.shouldMatch);
+            this._throwError(new EmptyMatchError(this.actualValue, this.shouldMatch));
          }
       } else if (this.actualValue.constructor === Object) {
          if ((Object.keys(this.actualValue).length === 0) !== this.shouldMatch) {
-            throw new EmptyMatchError(this.actualValue, this.shouldMatch);
+            this._throwError(new EmptyMatchError(this.actualValue, this.shouldMatch));
          }
       } else {
-         throw new TypeError("toBeEmpty requires value passed in to Expect to be an array, string or object literal");
+         this._throwError(new TypeError("toBeEmpty requires value passed in to Expect to be an array, string or object literal"));
       }
    }
 
@@ -211,7 +222,7 @@ export class Matcher {
    public toThrow() {
 
       if (this._actualValue instanceof Function === false) {
-         throw new TypeError("toThrow requires value passed in to Expect to be a function.");
+         this._throwError(new TypeError("toThrow requires value passed in to Expect to be a function."));
       }
 
       let errorThrown: Error;
@@ -224,7 +235,7 @@ export class Matcher {
       }
 
       if (errorThrown === undefined === this.shouldMatch) {
-         throw new ErrorMatchError(errorThrown, this.shouldMatch);
+         this._throwError(new ErrorMatchError(errorThrown, this.shouldMatch));
       }
    }
 
@@ -234,7 +245,7 @@ export class Matcher {
    public async toThrowAsync(): Promise<void> {
 
       if (this._actualValue instanceof Function === false) {
-         throw new TypeError("toThrow requires value passed in to Expect to be a function.");
+         this._throwError(new TypeError("toThrow requires value passed in to Expect to be a function."));
       }
 
       let errorThrown: Error;
@@ -247,7 +258,7 @@ export class Matcher {
       }
 
       if (errorThrown === undefined === this.shouldMatch) {
-         throw new ErrorMatchError(errorThrown, this.shouldMatch);
+         this._throwError(new ErrorMatchError(errorThrown, this.shouldMatch));
       }
       return Promise.resolve();
    }
@@ -260,7 +271,7 @@ export class Matcher {
    public toThrowError(errorType: new (...args: Array<any>) => Error, errorMessage: string) {
 
       if (this._actualValue instanceof Function === false) {
-         throw new TypeError("toThrowError requires value passed in to Expect to be a function.");
+         this._throwError(new TypeError("toThrowError requires value passed in to Expect to be a function."));
       }
 
       let threwRightError = false;
@@ -278,7 +289,7 @@ export class Matcher {
       }
 
       if (threwRightError !== this.shouldMatch) {
-         throw new ErrorMatchError(actualError, this.shouldMatch, (<any> errorType), errorMessage);
+         this._throwError(new ErrorMatchError(actualError, this.shouldMatch, (<any> errorType), errorMessage));
       }
    }
 
@@ -287,13 +298,13 @@ export class Matcher {
     */
    public toHaveBeenCalled(): FunctionSpyMatcher {
       if (this._isFunctionSpyOrSpiedOnFunction(this._actualValue) === false) {
-         throw new TypeError(
+         this._throwError(new TypeError(
              "toHaveBeenCalled requires value passed in to Expect to be a FunctionSpy or a spied on function."
-         );
+         ));
       }
 
       if (this._actualValue.calls.length === 0 === this.shouldMatch) {
-         throw new FunctionCallMatchError(this._actualValue, this.shouldMatch);
+         this._throwError(new FunctionCallMatchError(this._actualValue, this.shouldMatch));
       }
 
       return new FunctionSpyMatcher(this._actualValue);
@@ -305,9 +316,9 @@ export class Matcher {
     */
    public toHaveBeenCalledWith(...expectedArguments: Array<any>): FunctionSpyMatcher {
       if (this._isFunctionSpyOrSpiedOnFunction(this._actualValue) === false) {
-         throw new TypeError(
+         this._throwError(new TypeError(
              "toHaveBeenCalledWith requires value passed in to Expect to be a FunctionSpy or a spied on function."
-         );
+         ));
       }
 
       if (this._actualValue.calls.filter((call: any) => {
@@ -319,7 +330,7 @@ export class Matcher {
                   (expectedArgument instanceof TypeMatcher && expectedArgument.test(arg));
          }).length === expectedArguments.length; // and all call arguments match expected arguments
       }).length === 0 === this.shouldMatch) {
-         throw new FunctionCallMatchError(this._actualValue, this.shouldMatch, expectedArguments);
+         this._throwError(new FunctionCallMatchError(this._actualValue, this.shouldMatch, expectedArguments));
       }
 
       return new FunctionSpyMatcher(this._actualValue, expectedArguments);
@@ -330,11 +341,11 @@ export class Matcher {
     */
    public toHaveBeenSet() {
       if (this._actualValue instanceof PropertySpy === false) {
-         throw new TypeError("toHaveBeenSet requires value passed in to Expect to be a PropertySpy.");
+         this._throwError(new TypeError("toHaveBeenSet requires value passed in to Expect to be a PropertySpy."));
       }
 
       if (this._actualValue.setCalls.length === 0 === this.shouldMatch) {
-         throw new PropertySetMatchError(this._actualValue, this.shouldMatch);
+         this._throwError(new PropertySetMatchError(this._actualValue, this.shouldMatch));
       }
    }
 
@@ -344,11 +355,11 @@ export class Matcher {
     */
    public toHaveBeenSetTo(value: any) {
       if (this._actualValue instanceof PropertySpy === false) {
-         throw new TypeError("toHaveBeenSetTo requires value passed in to Expect to be a PropertySpy.");
+         this._throwError(new TypeError("toHaveBeenSetTo requires value passed in to Expect to be a PropertySpy."));
       }
 
       if (this._actualValue.setCalls.filter((call: any) => call.args[0] === value).length === 0 === this.shouldMatch) {
-         throw new PropertySetMatchError(this._actualValue, this.shouldMatch, value);
+         this._throwError(new PropertySetMatchError(this._actualValue, this.shouldMatch, value));
       }
    }
 

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -4,14 +4,14 @@ import {
    EqualMatchError,
    ErrorMatchError,
    ExactMatchError,
-   TypeMatchError,
    FunctionCallMatchError,
    GreaterThanMatchError,
    LessThanMatchError,
    MatchError,
    PropertySetMatchError,
    RegexMatchError,
-   TruthyMatchError
+   TruthyMatchError,
+   TypeMatchError
 } from "./errors";
 
 import {
@@ -42,6 +42,7 @@ export function Expect(actualValue: any) {
  * Gives functionality to ensure the outcome of a test is as expected
  */
 export class Matcher {
+   private _marker: TraceMarker | undefined;
 
    private _actualValue: any;
    protected get actualValue(): any {
@@ -51,22 +52,6 @@ export class Matcher {
    private _shouldMatch: boolean = true;
    protected get shouldMatch(): boolean {
        return this._shouldMatch;
-   }
-
-   private _marker: TraceMarker | undefined;
-
-   private _throwError(err: MatchError) {
-      let location: TraceLocation;
-      if (this._marker) {
-         location = this._marker.getLocation();
-      } else {
-         location = new TraceLocation(); // Empty location
-      }
-      err.fileName = location.file;
-      err.lineNumber = location.line;
-      err.columnNumber = location.col;
-
-      throw err;
    }
 
    public constructor(actualValue: any, marker?: TraceMarker) {
@@ -159,7 +144,8 @@ export class Matcher {
    public toContain(expectedContent: any) {
 
       if (this._actualValue instanceof Array === false && typeof this._actualValue !== "string") {
-         this._throwError(new TypeMatchError("toContain must only be used to check whether strings or arrays contain given contents."));
+         this._throwError(new TypeMatchError(
+            "toContain must only be used to check whether strings or arrays contain given contents."));
       }
 
       if (typeof this._actualValue === "string" && typeof expectedContent !== "string") {
@@ -212,7 +198,8 @@ export class Matcher {
     */
    public toBeEmpty() {
       if (null === this.actualValue || undefined === this.actualValue) {
-         this._throwError(new TypeMatchError("toBeEmpty requires value passed in to Expect not to be null or undefined"));
+         this._throwError(new TypeMatchError(
+            "toBeEmpty requires value passed in to Expect not to be null or undefined"));
       }
 
       if (typeof this.actualValue === "string" || Array.isArray(this.actualValue)) {
@@ -224,7 +211,8 @@ export class Matcher {
             this._throwError(new EmptyMatchError(this.actualValue, this.shouldMatch));
          }
       } else {
-         this._throwError(new TypeMatchError("toBeEmpty requires value passed in to Expect to be an array, string or object literal"));
+         this._throwError(new TypeMatchError(
+            "toBeEmpty requires value passed in to Expect to be an array, string or object literal"));
       }
    }
 
@@ -255,8 +243,6 @@ export class Matcher {
     * Checks that a function throws an error asynchronously when executed
     */
    public async toThrowAsync(): Promise<void> {
-
-       //console.trace("toThrowAsync");
 
       if (this._actualValue instanceof Function === false) {
          this._throwError(new TypeMatchError("toThrow requires value passed in to Expect to be a function."));
@@ -369,7 +355,8 @@ export class Matcher {
     */
    public toHaveBeenSetTo(value: any) {
       if (this._actualValue instanceof PropertySpy === false) {
-         this._throwError(new TypeMatchError("toHaveBeenSetTo requires value passed in to Expect to be a PropertySpy."));
+         this._throwError(new TypeMatchError(
+            "toHaveBeenSetTo requires value passed in to Expect to be a PropertySpy."));
       }
 
       if (this._actualValue.setCalls.filter((call: any) => call.args[0] === value).length === 0 === this.shouldMatch) {
@@ -415,4 +402,19 @@ export class Matcher {
       // all properties match so all is good
       return true;
    }
+
+   private _throwError(err: MatchError) {
+      let location: TraceLocation;
+      if (this._marker) {
+         location = this._marker.getLocation();
+      } else {
+         location = new TraceLocation(); // Empty location
+      }
+      err.fileName = location.file;
+      err.lineNumber = location.line;
+      err.columnNumber = location.col;
+
+      throw err;
+   }
+
 }

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -229,6 +229,29 @@ export class Matcher {
    }
 
    /**
+    * Checks that a function throws an error asynchronously when executed
+    */
+   public async toThrowAsync() {
+
+      if (this._actualValue instanceof Function === false) {
+         throw new TypeError("toThrow requires value passed in to Expect to be a function.");
+      }
+
+      let errorThrown: Error;
+
+      try {
+         await this._actualValue();
+      }
+      catch (error) {
+         errorThrown = error;
+      }
+
+      if (errorThrown === undefined === this.shouldMatch) {
+         throw new ErrorMatchError(errorThrown, this.shouldMatch);
+      }
+   }
+
+   /**
     * Checks that a function throws a specific error
     * @param errorType - the type of error that should be thrown
     * @param errorMessage - the message that the error should have

--- a/core/index.ts
+++ b/core/index.ts
@@ -5,6 +5,7 @@ import { TestFixture } from "./test-fixture";
 import { TestLoader } from "./test-loader";
 import { TestOutputStream } from "./test-output-stream";
 import { TestSet } from "./test-set";
+import { TraceLocation, TraceMarker } from "./tracing";
 
 export {
     Expect,
@@ -14,5 +15,7 @@ export {
     TestFixture,
     TestLoader,
     TestOutputStream,
-    TestSet
+    TestSet,
+    TraceLocation,
+    TraceMarker
 };

--- a/core/test-output-stream.ts
+++ b/core/test-output-stream.ts
@@ -115,7 +115,8 @@ export class TestOutputStream extends ReadableStream {
        let sanitisedActual = JSON.stringify(error.actual);
        let sanitisedExpected = JSON.stringify(error.expected);
 
-       this._writeFailure(sanitisedMessage, sanitisedActual, sanitisedExpected);
+       this._writeFailure(sanitisedMessage, sanitisedActual, sanitisedExpected,
+               undefined, error.fileName, error.lineNumber, error.columnNumber);
 
    }
 
@@ -128,7 +129,7 @@ export class TestOutputStream extends ReadableStream {
 
    }
 
-   private _writeFailure(message: string, actual: string, expected: string, stack?: string): void {
+   private _writeFailure(message: string, actual: string, expected: string, stack?: string, fileName?: string, lineNumber?: number, columnNumber?: number): void {
 
        let output =
            " ---\n" +
@@ -137,6 +138,15 @@ export class TestOutputStream extends ReadableStream {
            "   data:\n" +
            "     got: " + actual + "\n" +
            "     expect: " + expected + "\n";
+       if (fileName) {
+           output = output + "   file: " + fileName + "\n";
+       }
+       if (lineNumber) {
+           output = output + "   line: " + lineNumber + "\n";
+       }
+       if (columnNumber) {
+           output = output + "   col: " + columnNumber + "\n";
+       }
 
        if (stack) {
            output = output + "     stack: |\n";

--- a/core/test-output-stream.ts
+++ b/core/test-output-stream.ts
@@ -129,7 +129,15 @@ export class TestOutputStream extends ReadableStream {
 
    }
 
-   private _writeFailure(message: string, actual: string, expected: string, stack?: string, fileName?: string, lineNumber?: number, columnNumber?: number): void {
+   private _writeFailure(
+       message: string,
+       actual: string,
+       expected: string,
+       stack?: string,
+       fileName?: string,
+       lineNumber?: number,
+       columnNumber?: number
+   ): void {
 
        let output =
            " ---\n" +
@@ -141,10 +149,10 @@ export class TestOutputStream extends ReadableStream {
        if (fileName) {
            output = output + "   file: " + fileName + "\n";
        }
-       if (lineNumber) {
+       if (lineNumber > 0) {
            output = output + "   line: " + lineNumber + "\n";
        }
-       if (columnNumber) {
+       if (columnNumber > 0) {
            output = output + "   col: " + columnNumber + "\n";
        }
 

--- a/core/tracing.ts
+++ b/core/tracing.ts
@@ -1,0 +1,86 @@
+require('source-map-support').install();
+
+export class TraceLocation {
+    public func: string;
+    public file: string;
+    public line: number;
+    public col:  number;
+
+    public constructor() {
+        this.file = "<no info>";
+        this.func = "<no info>";
+        this.line = -1;
+        this.col  = -1;
+    }
+
+    public toString(): string {
+        return `at ${this.func} (${this.file}:${this.line}:${this.col}`;
+    }
+}
+
+export class TraceMarker {
+    private _stackState: string;
+
+    /**
+     * Return the location of where this routine was called from
+     */
+    public static here(callDepth = 1): TraceLocation {
+        let tm = new TraceMarker();
+        return tm.mark(callDepth).getLocation();
+    }
+
+    /**
+     * Constructor
+     */
+    public constructor() {
+    }
+
+    /**
+     * Mark the "current" location.
+     *
+     * @param callDepth is the call nesting if used directly no
+     *        value is necessary and the default is 0. But if you
+     *        use TraceMarker.mark in a subroutine and you want to
+     *        mark where that subroutine was called from you need
+     *        callDepth = 1 or the approprate value.
+     */
+    public mark(callDepth: number = 0): TraceMarker {
+        let saveStackTraceLimit = Error.stackTraceLimit;
+        Error.stackTraceLimit = callDepth + 1;
+        let err = new Error();
+        Error.captureStackTrace(err, this.mark);
+        Error.stackTraceLimit = saveStackTraceLimit;
+        //console.log(`${err.stack}`);
+        this._stackState = err.stack;
+        return this;
+    }
+
+
+    /**
+     * Return the TraceLocation
+     *
+     */
+    public getLocation(): TraceLocation {
+        //console.log(`${this.stackState}`);
+        let stack = this._stackState.split("\n");
+        let location = new TraceLocation();
+        if (stack.length >= 2) {
+            //console.log(`stack[tos]=${stack[stack.length - 1]}`);
+            let r = /.*? at (.*?) \((.*?):(\d+):(\d+)\)/.exec(`${stack[stack.length - 1]}`);
+            //console.log(`r=${r}`);
+            if (r.length > 2) {
+                location.file = r[2];
+            }
+            if (r.length > 1) {
+                location.func = r[1];
+            }
+            if (r.length > 3) {
+                location.line = Number(r[3]);
+            }
+            if (r.length > 4) {
+                location.col = Number(r[4]);
+            }
+        }
+        return location;
+    }
+}

--- a/core/tracing.ts
+++ b/core/tracing.ts
@@ -1,10 +1,10 @@
-require('source-map-support').install();
+require("source-map-support").install();
 
 export class TraceLocation {
     public func: string;
     public file: string;
     public line: number;
-    public col:  number;
+    public col: number;
 
     public constructor() {
         this.file = "<no info>";
@@ -19,8 +19,6 @@ export class TraceLocation {
 }
 
 export class TraceMarker {
-    private _stackState: string;
-
     /**
      * Return the location of where this routine was called from
      */
@@ -29,11 +27,7 @@ export class TraceMarker {
         return tm.mark(callDepth).getLocation();
     }
 
-    /**
-     * Constructor
-     */
-    public constructor() {
-    }
+    private _stackState: string;
 
     /**
      * Mark the "current" location.
@@ -50,24 +44,23 @@ export class TraceMarker {
         let err = new Error();
         Error.captureStackTrace(err, this.mark);
         Error.stackTraceLimit = saveStackTraceLimit;
-        //console.log(`${err.stack}`);
+        // console.log(`${err.stack}`);
         this._stackState = err.stack;
         return this;
     }
-
 
     /**
      * Return the TraceLocation
      *
      */
     public getLocation(): TraceLocation {
-        //console.log(`${this.stackState}`);
+        // console.log(`${this.stackState}`);
         let stack = this._stackState.split("\n");
         let location = new TraceLocation();
         if (stack.length >= 2) {
-            //console.log(`stack[tos]=${stack[stack.length - 1]}`);
+            // console.log(`stack[tos]=${stack[stack.length - 1]}`);
             let r = /.*? at (.*?) \((.*?):(\d+):(\d+)\)/.exec(`${stack[stack.length - 1]}`);
-            //console.log(`r=${r}`);
+            // console.log(`r=${r}`);
             if (r.length > 2) {
                 location.file = r[2];
             }

--- a/test/unit-tests/expect-tests/to-throw.spec.ts
+++ b/test/unit-tests/expect-tests/to-throw.spec.ts
@@ -1,4 +1,4 @@
-import { Expect, Test, TestCase } from "../../../core/alsatian-core";
+import { AsyncTest, Expect, Test, TestCase } from "../../../core/alsatian-core";
 import { ErrorMatchError } from "../../../core/errors/error-match-error";
 
 export class ToThrowTests {
@@ -149,5 +149,33 @@ export class ToThrowTests {
       Expect(errorMatchError).toBeDefined();
       Expect(errorMatchError).not.toBeNull();
       Expect(errorMatchError.expected).toBe("error not to be thrown.");
+   }
+
+   // Asynchronous throw
+   private async asyncThrowError(delayMs: number): Promise<void> {
+      return new Promise<void>((_, reject) => {
+         setTimeout(reject(new Error("Timeout then reject")), delayMs);
+      });
+   }
+
+   // Asynchronous non-throw
+   private async asyncNonThrowError(delayMs: number): Promise<void> {
+      return new Promise<void>((resolve) => {
+         setTimeout(resolve(), delayMs);
+      });
+   }
+
+   @TestCase(0)
+   @TestCase(100)
+   @AsyncTest("Test toThrowAsyncShouldThrow")
+   public async testToThrowAsyncShouldThrow(delayMs: number) {
+      Expect(async () => this.asyncThrowError(delayMs)).toThrowAsync();
+   }
+
+   @TestCase(0)
+   @TestCase(100)
+   @AsyncTest("Test toThrowAsync")
+   public async testToThrowAsyncShouldNotThrow(delayMs: number) {
+      Expect(async () => this.asyncNonThrowError(delayMs)).not.toThrowAsync();
    }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
       "preserveConstEnums": true,
       "experimentalDecorators": true,
       "emitDecoratorMetadata": true,
-      "lib": [ "es2015" ]
+      "lib": [ "DOM", "es2015" ]
    },
    "buildOnSave": false,
    "compileOnSave": true,


### PR DESCRIPTION
Here is an attempt to "fix" issue #366. I've added fileName, lineNumber and columnNumber to MatchError and so that "all" errors can report the location. I've created TraceLocation and TraceMarker which allows users of tracing to create a marker which "marks" a location in the source code and its passed to the Matcher.constructor and saved in Matcher._marker.

I then added _throwError which all methods which throw an error call, passing an MatchError. _throwError then converts the TraceMarker to a TraceLocation and initializes the fileName, lineNumber and columnNumber fields which can then be used to display that information to the user.

Right now the two biggest issues are that there are many tests that are expecting TypeError which I changed to TypeMatchError and these fail. I didn't want to go to the effort of fixing the tests unless it was thought this was the right direction.

The other problem is that the location information is only shown when `--tap` output is used. If `--tap` isn't used the failure output looks to be generated by `tap-bark` so either we need to change `tap-bark` or produce the output some other way. Again, more than I wanted to bite off until I got some feed back.

I've built this on top of my "async" code but only because it was convenient and it did expose some greater challenges as I'd originally tried to do the "marking" in the toXxx methods but that didn't work well because locating the method throwing an error in a async routine would require searching the stack frame and that seemed brittle. So instead I've chosen to add the "marking" in the Expect routine which is means the location of the caller in the stack frame is well defined.

Anyway, let me know what you think, I could be barking up the wrong tree, but I think is a very worth while feature. Of course YMMV.
