### PR TITLE
Add toThrowAsync and toThrowErrorAsync

### DIFF
--- a/core/errors/error-match-error.ts
+++ b/core/errors/error-match-error.ts
@@ -29,10 +29,10 @@ export class ErrorMatchError extends MatchError {
       }
       else {
          if (shouldMatch) {
-            this.message = `Expected an error to be thrown but no errors were thown.`;
+            this.message = `Expected an error to be thrown but no errors were thrown.`;
          }
          else {
-            this.message = `Expected an error not to be thrown but an error was thown.`;
+            this.message = `Expected an error not to be thrown but an error was thrown.`;
          }
       }
    }

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -228,6 +228,30 @@ export class Matcher {
       }
    }
 
+   public async toThrowAsync(): Promise<void> {
+
+      return new Promise<void>(async (resolve, reject) => {
+         if (this._actualValue instanceof Function === false) {
+            return reject(new TypeError("toThrowAsync requires value passed in to Expect to be a function."));
+         }
+
+         let errorThrown: Error;
+
+         try {
+            await this._actualValue();
+         }
+         catch (error) {
+            errorThrown = error;
+         }
+
+         if (errorThrown === undefined === this.shouldMatch) {
+            return reject(new ErrorMatchError(errorThrown, this.shouldMatch));
+         } else {
+            return resolve();
+         }
+      });
+   }
+
    /**
     * Checks that a function throws a specific error
     * @param errorType - the type of error that should be thrown
@@ -256,6 +280,40 @@ export class Matcher {
       if (threwRightError !== this.shouldMatch) {
          throw new ErrorMatchError(actualError, this.shouldMatch, (<any> errorType), errorMessage);
       }
+   }
+
+   /**
+    * Checks that a function throws a specific error asynchronously
+    * @param errorType - the type of error that should be thrown
+    * @param errorMessage - the message that the error should have
+    */
+   public async toThrowErrorAsync(errorType: new (...args: Array<any>) => Error, errorMessage: string): Promise<void> {
+
+      return new Promise<void>(async (resolve, reject) => {
+         if (this._actualValue instanceof Function === false) {
+            return reject(new TypeError("toThrowErrorAsync requires value passed to Expect to be a function."));
+         }
+
+         let threwRightError = false;
+         let actualError: Error;
+
+         try {
+            await this._actualValue();
+         }
+         catch (error) {
+            actualError = error;
+
+            if (error instanceof errorType && error.message === errorMessage) {
+               threwRightError = true;
+            }
+         }
+
+         if (threwRightError !== this.shouldMatch) {
+            return reject(new ErrorMatchError(actualError, this.shouldMatch, (<any> errorType), errorMessage));
+         } else {
+            return resolve();
+         }
+      });
    }
 
    /**

--- a/core/expect.ts
+++ b/core/expect.ts
@@ -228,28 +228,24 @@ export class Matcher {
       }
    }
 
-   public async toThrowAsync(): Promise<void> {
+   public async toThrowAsync() {
 
-      return new Promise<void>(async (resolve, reject) => {
-         if (this._actualValue instanceof Function === false) {
-            return reject(new TypeError("toThrowAsync requires value passed in to Expect to be a function."));
-         }
+       if (this._actualValue instanceof Function === false) {
+          throw new TypeError("toThrowAsync requires value passed in to Expect to be a function.");
+       }
 
-         let errorThrown: Error;
+       let errorThrown: Error;
 
-         try {
-            await this._actualValue();
-         }
-         catch (error) {
-            errorThrown = error;
-         }
+       try {
+          await this._actualValue();
+       }
+       catch (error) {
+          errorThrown = error;
+       }
 
-         if (errorThrown === undefined === this.shouldMatch) {
-            return reject(new ErrorMatchError(errorThrown, this.shouldMatch));
-         } else {
-            return resolve();
-         }
-      });
+       if (errorThrown === undefined === this.shouldMatch) {
+          throw new ErrorMatchError(errorThrown, this.shouldMatch);
+       }
    }
 
    /**
@@ -287,33 +283,29 @@ export class Matcher {
     * @param errorType - the type of error that should be thrown
     * @param errorMessage - the message that the error should have
     */
-   public async toThrowErrorAsync(errorType: new (...args: Array<any>) => Error, errorMessage: string): Promise<void> {
+   public async toThrowErrorAsync(errorType: new (...args: Array<any>) => Error, errorMessage: string) {
 
-      return new Promise<void>(async (resolve, reject) => {
-         if (this._actualValue instanceof Function === false) {
-            return reject(new TypeError("toThrowErrorAsync requires value passed to Expect to be a function."));
-         }
+       if (this._actualValue instanceof Function === false) {
+          throw new TypeError("toThrowErrorAsync requires value passed to Expect to be a function.");
+       }
 
-         let threwRightError = false;
-         let actualError: Error;
+       let threwRightError = false;
+       let actualError: Error;
 
-         try {
-            await this._actualValue();
-         }
-         catch (error) {
-            actualError = error;
+       try {
+          await this._actualValue();
+       }
+       catch (error) {
+          actualError = error;
 
-            if (error instanceof errorType && error.message === errorMessage) {
-               threwRightError = true;
-            }
-         }
+          if (error instanceof errorType && error.message === errorMessage) {
+             threwRightError = true;
+          }
+       }
 
-         if (threwRightError !== this.shouldMatch) {
-            return reject(new ErrorMatchError(actualError, this.shouldMatch, (<any> errorType), errorMessage));
-         } else {
-            return resolve();
-         }
-      });
+       if (threwRightError !== this.shouldMatch) {
+          throw new ErrorMatchError(actualError, this.shouldMatch, (<any> errorType), errorMessage);
+       }
    }
 
    /**

--- a/test/integration-tests/gulp/runner.ts
+++ b/test/integration-tests/gulp/runner.ts
@@ -6,7 +6,7 @@ import { AsyncTest, Expect, TestCase, Timeout } from "../../../core/alsatian-cor
 export class GulpIntegrationTests {
 
    @AsyncTest()
-   @Timeout(5000)
+   @Timeout(10000)
    public toBeExpectations() {
 
       const result = child
@@ -33,7 +33,7 @@ export class GulpIntegrationTests {
    @TestCase("setup")
    @TestCase("teardown")
    @AsyncTest()
-   @Timeout(5000)
+   @Timeout(10000)
    public syntaxTests(syntaxTestName: string) {
 
       const result = child

--- a/test/unit-tests/errors/error-match-error.spec.ts
+++ b/test/unit-tests/errors/error-match-error.spec.ts
@@ -7,14 +7,14 @@ export class ErrorMatchErrorTests {
    public noActualErrorShouldGiveCorrectMessage() {
       let error = new ErrorMatchError(null, true);
 
-      Expect(error.message).toBe("Expected an error to be thrown but no errors were thown.");
+      Expect(error.message).toBe("Expected an error to be thrown but no errors were thrown.");
    }
 
    @Test()
    public actualErrorThrownWhenNoneExpectedShouldGiveCorrectMessage() {
       let error = new ErrorMatchError(new Error(), false);
 
-      Expect(error.message).toBe("Expected an error not to be thrown but an error was thown.");
+      Expect(error.message).toBe("Expected an error not to be thrown but an error was thrown.");
    }
 
    @TestCase(Error, EvalError)

--- a/test/unit-tests/expect-tests/to-throw-async.spec.ts
+++ b/test/unit-tests/expect-tests/to-throw-async.spec.ts
@@ -1,0 +1,222 @@
+import { AsyncTest, Expect, TestCase } from "../../../core/alsatian-core";
+import { ErrorMatchError } from "../../../core/errors/error-match-error";
+
+export class ToThrowAsyncTests {
+   // Asynchronous throw
+   private async asyncThrowFunction(delayMs: number): Promise<void> {
+      return new Promise<void>((_, reject) => {
+         setTimeout(reject(new Error("Timeout then reject")), delayMs);
+      });
+   }
+
+   // Asynchronous non-throw
+   private async asyncNonThrowFunction(delayMs: number): Promise<void> {
+      return new Promise<void>((resolve) => {
+         setTimeout(resolve(), delayMs);
+      });
+   }
+
+   @TestCase(0)
+   @TestCase(100)
+   @AsyncTest()
+   public async asyncFunctionThrowsErrorPasses(delayMs: number) {
+      // Exect to and error NOT be thrown
+      await Expect(async() => {
+         // Expect an error to be thrown
+         await Expect(async () => this.asyncThrowFunction(delayMs)).toThrowAsync();
+      }).not.toThrowAsync();
+   }
+
+   @TestCase(0)
+   @TestCase(100)
+   @AsyncTest()
+   public async asyncFunctionThrowDoesNotErrorFails(delayMs: number) {
+      // Expect a failure to be thrown
+      await Expect(async () => {
+         // invoking asyncNonThrowError but expect toThrowAsync so it will fail
+         await Expect(() => this.asyncNonThrowFunction(delayMs)).toThrowAsync();
+      }).toThrowAsync();
+   }
+
+   @TestCase(0)
+   @TestCase(100)
+   @AsyncTest()
+   public async asyncFunctionDoesNotThrowErrorFailsWithCorrectError(delayMs: number) {
+      await Expect(async () => {
+         await Expect(() => this.asyncNonThrowFunction(delayMs)).toThrowAsync();
+      }).toThrowErrorAsync(ErrorMatchError, "Expected an error to be thrown but no errors were thrown.");
+   }
+
+   @TestCase(0)
+   @TestCase(100)
+   @AsyncTest()
+   public async asyncFunctionDoesNotThrowErrorPassesWhenShouldNotThrow(delayMs: number) {
+      await Expect(async () => {
+         await Expect(() => this.asyncNonThrowFunction(delayMs)).not.toThrowAsync();
+      }).not.toThrowAsync();
+   }
+
+   @TestCase(0)
+   @TestCase(100)
+   @AsyncTest()
+   public async asyncFunctionThrowsErrorFailsWhenShouldNotThrow(delayMs: number) {
+      await Expect(async () => {
+         await Expect(() => this.asyncThrowFunction(delayMs)).not.toThrowAsync();
+      }).toThrowAsync();
+   }
+
+   @TestCase(0)
+   @TestCase(100)
+   @AsyncTest()
+   public async asyncFunctionThrowsErrorFailsWithCorrectError(delayMs: number) {
+      await Expect(async () => {
+         await Expect(() => this.asyncThrowFunction(delayMs)).not.toThrowAsync();
+      }).toThrowErrorAsync(ErrorMatchError, "Expected an error not to be thrown but an error was thrown.");
+   }
+
+   @TestCase(undefined)
+   @TestCase(null)
+   @TestCase("")
+   @TestCase("something")
+   @TestCase(0)
+   @TestCase(1)
+   @TestCase(42)
+   @TestCase({})
+   @TestCase({ an: "object"})
+   @TestCase([])
+   @TestCase([ "an", "array" ])
+   @AsyncTest()
+   public async asyncCheckingWhetherNonFunctionThrowsShouldThrow(actualValue: any) {
+      await Expect(async () => {
+         await Expect(actualValue).toThrowAsync();
+      }).toThrowErrorAsync(TypeError, "toThrowAsync requires value passed in to Expect to be a function.");
+   }
+
+   @TestCase(undefined)
+   @TestCase(null)
+   @TestCase("")
+   @TestCase("something")
+   @TestCase(0)
+   @TestCase(1)
+   @TestCase(42)
+   @TestCase({})
+   @TestCase({ an: "object"})
+   @TestCase([])
+   @TestCase([ "an", "array" ])
+   @AsyncTest()
+   public async asyncCheckingWhetherNonFunctionDoesNotThrowShouldThrow(actualValue: any) {
+      await Expect(async () => {
+         await Expect(actualValue).not.toThrowAsync();
+      }).toThrowErrorAsync(TypeError, "toThrowAsync requires value passed in to Expect to be a function.");
+   }
+
+   @AsyncTest()
+   public async asyncActualValueAndShouldNotMatchErrorM() {
+
+      let errorMatchError: ErrorMatchError;
+
+      try {
+         await Expect(() => {}).toThrowAsync();
+      }
+      catch (error) {
+         errorMatchError = error;
+      }
+
+      Expect(errorMatchError).toBeDefined();
+      Expect(errorMatchError).not.toBeNull();
+      Expect(errorMatchError.actual).toBe("error was not thrown.");
+   }
+
+   @TestCase(EvalError, "something went wrong")
+   @TestCase(ReferenceError, "A much worse thing happened!")
+   @TestCase(SyntaxError, "THE END IS NIGH")
+   public async asyncActualValueAndShouldNotMatchShouldBeSetToErrorWasThrown(
+      actualErrorType: new (message: string) => Error, actualErrorMessage: string) {
+
+      let errorMatchError: ErrorMatchError;
+
+      try {
+         await Expect(() => { throw new actualErrorType(actualErrorMessage); }).not.toThrowAsync();
+      }
+      catch (error) {
+         errorMatchError = error;
+      }
+
+      Expect(errorMatchError).toBeDefined();
+      Expect(errorMatchError).not.toBeNull();
+      Expect(errorMatchError.actual)
+         .toBe(`${(<any> actualErrorType).name} error was thrown with message "${actualErrorMessage}".`);
+   }
+
+   @AsyncTest()
+   public async asyncActualValueAndShouldMatchShouldBeSetToErrorToBeThrown() {
+
+      let errorMatchError: ErrorMatchError;
+
+      try {
+         await Expect(() => {}).toThrowAsync();
+      }
+      catch (error) {
+         errorMatchError = error;
+      }
+
+      Expect(errorMatchError).toBeDefined();
+      Expect(errorMatchError).not.toBeNull();
+      Expect(errorMatchError.expected).toBe("error to be thrown.");
+   }
+
+   @AsyncTest()
+   public async asyncExpectedValueAndShouldNotMatchShouldBeSetToErrorNotToBeThrown() {
+
+      let errorMatchError: ErrorMatchError;
+
+      try {
+         await Expect(() => { throw new Error(); }).not.toThrowAsync();
+      }
+      catch (error) {
+         errorMatchError = error;
+      }
+
+      Expect(errorMatchError).toBeDefined();
+      Expect(errorMatchError).not.toBeNull();
+      Expect(errorMatchError.expected).toBe("error not to be thrown.");
+   }
+
+   @AsyncTest()
+   public async asyncCheckingToThrowErrorAsyncPassesWhenErrorsMatch() {
+
+      await Expect(async () => {
+         await Expect(() => { throw new EvalError("An EvalError"); }).toThrowErrorAsync(EvalError, "An EvalError");
+      }).toBeTruthy();
+   }
+
+   @AsyncTest()
+   public async asyncCheckingToThrowErrorAsyncFailsOnWhenErrorsDoNotMatch() {
+
+      await Expect(async () => {
+         await Expect(() => {
+            throw new EvalError("An EvalError");
+         }).toThrowErrorAsync(SyntaxError, "An SyntaxError");
+      }).toThrowAsync();
+   }
+
+   @TestCase(undefined)
+   @TestCase(null)
+   @TestCase("")
+   @TestCase("something")
+   @TestCase(0)
+   @TestCase(1)
+   @TestCase(42)
+   @TestCase({})
+   @TestCase({ an: "object"})
+   @TestCase([])
+   @TestCase([ "an", "array" ])
+   @AsyncTest()
+   public async asyncCheckingWhetherNonFunctionForToThrowErrorAcyncDoesThrow(actualValue: any) {
+      await Expect(async () => {
+         await Expect(actualValue)
+            .toThrowErrorAsync(TypeError, "toThrowAsync requires value passed to Expect to be a function.");
+      }).toThrowAsync();
+   }
+
+}

--- a/test/unit-tests/expect-tests/to-throw-async.spec.ts
+++ b/test/unit-tests/expect-tests/to-throw-async.spec.ts
@@ -5,72 +5,68 @@ export class ToThrowAsyncTests {
    // Asynchronous throw
    private async asyncThrowFunction(delayMs: number): Promise<void> {
       return new Promise<void>((_, reject) => {
-         setTimeout(reject(new Error("Timeout then reject")), delayMs);
+         setTimeout(() => reject(new Error("Timeout then reject")), delayMs);
       });
    }
 
    // Asynchronous non-throw
    private async asyncNonThrowFunction(delayMs: number): Promise<void> {
       return new Promise<void>((resolve) => {
-         setTimeout(resolve(), delayMs);
+         setTimeout(() => resolve(), delayMs);
       });
    }
 
    @TestCase(0)
    @TestCase(100)
-   @AsyncTest()
+   @AsyncTest("Test toThrowAsync catches thrown errors and does not rethrow")
    public async asyncFunctionThrowsErrorPasses(delayMs: number) {
-      // Exect to and error NOT be thrown
-      await Expect(async() => {
-         // Expect an error to be thrown
-         await Expect(async () => this.asyncThrowFunction(delayMs)).toThrowAsync();
+      await Expect(async () => {
+         await Expect(async () => await this.asyncThrowFunction(delayMs)).toThrowAsync();
       }).not.toThrowAsync();
    }
 
    @TestCase(0)
    @TestCase(100)
-   @AsyncTest()
+   @AsyncTest("Test toThrowAsync throws and error if an error is not thrown")
    public async asyncFunctionThrowDoesNotErrorFails(delayMs: number) {
-      // Expect a failure to be thrown
       await Expect(async () => {
-         // invoking asyncNonThrowError but expect toThrowAsync so it will fail
-         await Expect(() => this.asyncNonThrowFunction(delayMs)).toThrowAsync();
+         await Expect(async () => await this.asyncNonThrowFunction(delayMs)).toThrowAsync();
       }).toThrowAsync();
    }
 
    @TestCase(0)
    @TestCase(100)
-   @AsyncTest()
+   @AsyncTest("Test toThrowAsync throws a ErrorMatchError and toThrowErrorAsync catches it")
    public async asyncFunctionDoesNotThrowErrorFailsWithCorrectError(delayMs: number) {
       await Expect(async () => {
-         await Expect(() => this.asyncNonThrowFunction(delayMs)).toThrowAsync();
+         await Expect(async () => await this.asyncNonThrowFunction(delayMs)).toThrowAsync();
       }).toThrowErrorAsync(ErrorMatchError, "Expected an error to be thrown but no errors were thrown.");
    }
 
    @TestCase(0)
    @TestCase(100)
-   @AsyncTest()
+   @AsyncTest("Test not.toThrowAsync does not throw when it shouldn't")
    public async asyncFunctionDoesNotThrowErrorPassesWhenShouldNotThrow(delayMs: number) {
       await Expect(async () => {
-         await Expect(() => this.asyncNonThrowFunction(delayMs)).not.toThrowAsync();
+         await Expect(async () => await this.asyncNonThrowFunction(delayMs)).not.toThrowAsync();
       }).not.toThrowAsync();
    }
 
    @TestCase(0)
    @TestCase(100)
-   @AsyncTest()
+   @AsyncTest("Test not.toThrowAsync does throw when it should")
    public async asyncFunctionThrowsErrorFailsWhenShouldNotThrow(delayMs: number) {
       await Expect(async () => {
-         await Expect(() => this.asyncThrowFunction(delayMs)).not.toThrowAsync();
+         await Expect(async () => await this.asyncThrowFunction(delayMs)).not.toThrowAsync();
       }).toThrowAsync();
    }
 
    @TestCase(0)
    @TestCase(100)
-   @AsyncTest()
+   @AsyncTest("Test not.toThrowAsync thows an ErrorMatchError when it should")
    public async asyncFunctionThrowsErrorFailsWithCorrectError(delayMs: number) {
       await Expect(async () => {
-         await Expect(() => this.asyncThrowFunction(delayMs)).not.toThrowAsync();
+         await Expect(async () => await this.asyncThrowFunction(delayMs)).not.toThrowAsync();
       }).toThrowErrorAsync(ErrorMatchError, "Expected an error not to be thrown but an error was thrown.");
    }
 
@@ -85,7 +81,7 @@ export class ToThrowAsyncTests {
    @TestCase({ an: "object"})
    @TestCase([])
    @TestCase([ "an", "array" ])
-   @AsyncTest()
+   @AsyncTest("Test toThrowAsync throws a TypeError when it should")
    public async asyncCheckingWhetherNonFunctionThrowsShouldThrow(actualValue: any) {
       await Expect(async () => {
          await Expect(actualValue).toThrowAsync();
@@ -103,14 +99,14 @@ export class ToThrowAsyncTests {
    @TestCase({ an: "object"})
    @TestCase([])
    @TestCase([ "an", "array" ])
-   @AsyncTest()
+   @AsyncTest("Test not.toThrowAsync throws a TypeError when it should")
    public async asyncCheckingWhetherNonFunctionDoesNotThrowShouldThrow(actualValue: any) {
       await Expect(async () => {
          await Expect(actualValue).not.toThrowAsync();
       }).toThrowErrorAsync(TypeError, "toThrowAsync requires value passed in to Expect to be a function.");
    }
 
-   @AsyncTest()
+   @AsyncTest("Test toThrowAsync errors are caught and error is type ErrorMatchError")
    public async asyncActualValueAndShouldNotMatchErrorM() {
 
       let errorMatchError: ErrorMatchError;
@@ -130,6 +126,7 @@ export class ToThrowAsyncTests {
    @TestCase(EvalError, "something went wrong")
    @TestCase(ReferenceError, "A much worse thing happened!")
    @TestCase(SyntaxError, "THE END IS NIGH")
+   @AsyncTest("Test not.toThrowAsync errors are caught and error is type ErrorMatchError's")
    public async asyncActualValueAndShouldNotMatchShouldBeSetToErrorWasThrown(
       actualErrorType: new (message: string) => Error, actualErrorMessage: string) {
 
@@ -148,24 +145,7 @@ export class ToThrowAsyncTests {
          .toBe(`${(<any> actualErrorType).name} error was thrown with message "${actualErrorMessage}".`);
    }
 
-   @AsyncTest()
-   public async asyncActualValueAndShouldMatchShouldBeSetToErrorToBeThrown() {
-
-      let errorMatchError: ErrorMatchError;
-
-      try {
-         await Expect(() => {}).toThrowAsync();
-      }
-      catch (error) {
-         errorMatchError = error;
-      }
-
-      Expect(errorMatchError).toBeDefined();
-      Expect(errorMatchError).not.toBeNull();
-      Expect(errorMatchError.expected).toBe("error to be thrown.");
-   }
-
-   @AsyncTest()
+   @AsyncTest("Test not.toThrowAsync error are caught and error is ErrorMatchError")
    public async asyncExpectedValueAndShouldNotMatchShouldBeSetToErrorNotToBeThrown() {
 
       let errorMatchError: ErrorMatchError;
@@ -182,7 +162,7 @@ export class ToThrowAsyncTests {
       Expect(errorMatchError.expected).toBe("error not to be thrown.");
    }
 
-   @AsyncTest()
+   @AsyncTest("Test toThrowErrorAsync catches errors of the correct type and passes")
    public async asyncCheckingToThrowErrorAsyncPassesWhenErrorsMatch() {
 
       await Expect(async () => {
@@ -190,13 +170,11 @@ export class ToThrowAsyncTests {
       }).toBeTruthy();
    }
 
-   @AsyncTest()
+   @AsyncTest("Test toThrowErrorAsync catches errors and if it isn't correct throws an Error")
    public async asyncCheckingToThrowErrorAsyncFailsOnWhenErrorsDoNotMatch() {
 
       await Expect(async () => {
-         await Expect(() => {
-            throw new EvalError("An EvalError");
-         }).toThrowErrorAsync(SyntaxError, "An SyntaxError");
+         await Expect(() => { throw new EvalError("An EvalError"); }).toThrowErrorAsync(SyntaxError, "An SyntaxError");
       }).toThrowAsync();
    }
 
@@ -211,7 +189,7 @@ export class ToThrowAsyncTests {
    @TestCase({ an: "object"})
    @TestCase([])
    @TestCase([ "an", "array" ])
-   @AsyncTest()
+   @AsyncTest("Test toThrowErrorAsync throws a TypeError when it should")
    public async asyncCheckingWhetherNonFunctionForToThrowErrorAcyncDoesThrow(actualValue: any) {
       await Expect(async () => {
          await Expect(actualValue)

--- a/test/unit-tests/expect-tests/to-throw.spec.ts
+++ b/test/unit-tests/expect-tests/to-throw.spec.ts
@@ -22,7 +22,7 @@ export class ToThrowTests {
       let nonThrowFunction = () => {};
 
       Expect(() => Expect(nonThrowFunction).toThrow())
-        .toThrowError(ErrorMatchError, "Expected an error to be thrown but no errors were thown.");
+        .toThrowError(ErrorMatchError, "Expected an error to be thrown but no errors were thrown.");
    }
 
    @Test()
@@ -44,7 +44,7 @@ export class ToThrowTests {
       let throwFunction = () => { throw new Error(); };
 
       Expect(() => Expect(throwFunction).not.toThrow())
-        .toThrowError(ErrorMatchError, "Expected an error not to be thrown but an error was thown.");
+        .toThrowError(ErrorMatchError, "Expected an error not to be thrown but an error was thrown.");
    }
 
    @TestCase(undefined)
@@ -150,4 +150,5 @@ export class ToThrowTests {
       Expect(errorMatchError).not.toBeNull();
       Expect(errorMatchError.expected).toBe("error not to be thrown.");
    }
+
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
       "preserveConstEnums": true,
       "experimentalDecorators": true,
       "emitDecoratorMetadata": true,
-      "lib": [ "DOM", "es2015" ]
+      "lib": [ "es2015" ]
    },
    "buildOnSave": false,
    "compileOnSave": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
       "preserveConstEnums": true,
       "experimentalDecorators": true,
       "emitDecoratorMetadata": true,
-      "lib": [ "es2015" ]
+      "lib": [ "DOM", "es2015" ]
    },
    "buildOnSave": false,
    "compileOnSave": true,


### PR DESCRIPTION
A solution to issue #353.

Added unit-tests for the new Matchers in
test/unit-tests/expect-tests/to-throw-async.spec.ts

Increased timeouts in test/integration-test/gulp/runner.ts

Fixed a misspelling of `thown` to `thrown`

<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

# Description

<!-- Now, we've created a handy checklist before submitting your pull request to ensure it goes smoothly
      (we checked the first one for you because we know it's true) -->

# Checklist

- [x] I am an awesome developer and proud of my code
- [ ] I added / updated / removed relevant unit or integration tests to prove my change works
- [ ] I ran all tests using ```npm test``` to make sure everything else still works
- [ ] I ran ```npm run review``` to ensure the code adheres to the repository standards

<!-- Thanks again, and if you'd like to add any further information you can do so below -->

# Additional Information
