### PR TITLE
Remove node js version 4 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "7"
   - "6"
-  - "4"
 os:
   - linux
   - osx


### PR DESCRIPTION
According to the [Node 6 release announcement](https://nodejs.org/en/blog/release/v6.0.0/)
Version 4 is now in Maintenance mode as of April 2017. It is also very
slow to build on travis. Finally, in a [PR 371](https://github.com/alsatian-test/alsatian/pull/371)
a [runtime syntax error](https://travis-ci.org/alsatian-test/alsatian/jobs/229130470)
is occurring because a default function parametersyntax is illegal in
the version of V8 being used:
```
/home/travis/build/alsatian-test/alsatian/node_modules/traceloc/out/traceloc.js:35
function here(callDepth = 0) {
                        ^
SyntaxError: Unexpected token =
    at exports.runInThisContext (vm.js:53:16)
```

I'm sure it could be made to run, but this seems a reasonable approach.

<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

# Description

<!-- Now, we've created a handy checklist before submitting your pull request to ensure it goes smoothly
      (we checked the first one for you because we know it's true) -->

# Checklist

- [x] I am an awesome developer and proud of my code
- [x] I added / updated / removed relevant unit or integration tests to prove my change works
- [x] I ran all tests using ```npm test``` to make sure everything else still works
- [x] I ran ```npm run review``` to ensure the code adheres to the repository standards

<!-- Thanks again, and if you'd like to add any further information you can do so below -->

# Additional Information
