### PR TITLE
allow absolute references for test specs

### DIFF
--- a/core/test-set.ts
+++ b/core/test-set.ts
@@ -49,7 +49,7 @@ export class TestSet {
    private _loadTestFixtures(testFileLocations: Array<string>) {
       testFileLocations.forEach(testFileLocation => {
 
-         testFileLocation = path.join(process.cwd(), testFileLocation);
+         testFileLocation = path.resolve(testFileLocation);
 
          if (this._globHelper.isGlob(testFileLocation)) {
             const physicalTestFileLocations = this._globHelper.resolve(testFileLocation);

--- a/test/unit-tests/test-set/load-test.spec.ts
+++ b/test/unit-tests/test-set/load-test.spec.ts
@@ -1,6 +1,7 @@
 import { GlobHelper, TestLoader } from "../../../core/";
 import { Expect, SpyOn, Test, TestCase } from "../../../core/alsatian-core";
 import { TestSet } from "../../../core/test-set";
+import { resolve, sep } from "path";
 
 export class LoadTestTests {
 
@@ -19,5 +20,83 @@ export class LoadTestTests {
       testSet.addTestsFromFiles("no-tests");
 
       Expect(testSet.testFixtures.length).toBe(0);
+   }
+
+   @TestCase("C:/test/spec.js")
+   @TestCase("D:/another/spec.somewhere.js")
+   @Test("absolute paths are resolved")
+   public absolutePathsAreResolved(path: string) {
+      const testLoader = new TestLoader(null);
+      const testLoaderSpy = SpyOn(testLoader, "loadTestFixture");
+      testLoaderSpy.andReturn([]);
+      testLoaderSpy.andStub();
+
+      const globHelper = new GlobHelper();
+      SpyOn(globHelper, "isGlob").andReturn(false);
+
+      const testSet = new TestSet(testLoader, globHelper);
+
+      testSet.addTestsFromFiles(path);
+
+      Expect(testLoader.loadTestFixture).toHaveBeenCalledWith(path.replace(/\//g, sep));
+   }
+
+   @TestCase("./spec.js")
+   @TestCase("spec.somewhere.js")
+   @TestCase("../another.test.js")
+   @Test("relative paths are resolved")
+   public relativePathsAreResolved(path: string) {
+      const testLoader = new TestLoader(null);
+      const testLoaderSpy = SpyOn(testLoader, "loadTestFixture");
+      testLoaderSpy.andReturn([]);
+      testLoaderSpy.andStub();
+
+      const globHelper = new GlobHelper();
+      SpyOn(globHelper, "isGlob").andReturn(false);
+
+      const testSet = new TestSet(testLoader, globHelper);
+
+      testSet.addTestsFromFiles(path);
+
+      Expect(testLoader.loadTestFixture).toHaveBeenCalledWith(resolve(path));
+   }
+
+   @TestCase("C:/*/spec.js")
+   @TestCase("D:/another/**/*.spec.somewhere.js")
+   @Test("absolute globs are resolved")
+   public absoluteGlobsAreResolved(path: string) {
+      const testLoader = new TestLoader(null);
+      const testLoaderSpy = SpyOn(testLoader, "loadTestFixture");
+      testLoaderSpy.andReturn([]);
+      testLoaderSpy.andStub();
+
+      const globHelper = new GlobHelper();
+      SpyOn(globHelper, "resolve").andReturn([]);
+
+      const testSet = new TestSet(testLoader, globHelper);
+
+      testSet.addTestsFromFiles(path);
+
+      Expect(globHelper.resolve).toHaveBeenCalledWith(path.replace(/\//g, sep));
+   }
+
+   @TestCase("./*.js")
+   @TestCase("**/*.js")
+   @TestCase("../*.test.js")
+   @Test("relative globs are resolved")
+   public relativeGlobsAreResolved(path: string) {
+      const testLoader = new TestLoader(null);
+      const testLoaderSpy = SpyOn(testLoader, "loadTestFixture");
+      testLoaderSpy.andReturn([]);
+      testLoaderSpy.andStub();
+
+      const globHelper = new GlobHelper();
+      SpyOn(globHelper, "resolve").andReturn([]);
+
+      const testSet = new TestSet(testLoader, globHelper);
+
+      testSet.addTestsFromFiles(path);
+
+      Expect(globHelper.resolve).toHaveBeenCalledWith(resolve(path));
    }
 }

--- a/test/unit-tests/test-set/load-test.spec.ts
+++ b/test/unit-tests/test-set/load-test.spec.ts
@@ -22,8 +22,8 @@ export class LoadTestTests {
       Expect(testSet.testFixtures.length).toBe(0);
    }
 
-   @TestCase("C:/test/spec.js")
-   @TestCase("D:/another/spec.somewhere.js")
+   @TestCase("/test/spec.js")
+   @TestCase("/another/spec.somewhere.js")
    @Test("absolute paths are resolved")
    public absolutePathsAreResolved(path: string) {
       const testLoader = new TestLoader(null);
@@ -38,7 +38,7 @@ export class LoadTestTests {
 
       testSet.addTestsFromFiles(path);
 
-      Expect(testLoader.loadTestFixture).toHaveBeenCalledWith(path.replace(/\//g, sep));
+      Expect(testLoader.loadTestFixture).toHaveBeenCalledWith(resolve(path));
    }
 
    @TestCase("./spec.js")
@@ -61,8 +61,8 @@ export class LoadTestTests {
       Expect(testLoader.loadTestFixture).toHaveBeenCalledWith(resolve(path));
    }
 
-   @TestCase("C:/*/spec.js")
-   @TestCase("D:/another/**/*.spec.somewhere.js")
+   @TestCase("/*/spec.js")
+   @TestCase("/another/**/*.spec.somewhere.js")
    @Test("absolute globs are resolved")
    public absoluteGlobsAreResolved(path: string) {
       const testLoader = new TestLoader(null);
@@ -77,7 +77,7 @@ export class LoadTestTests {
 
       testSet.addTestsFromFiles(path);
 
-      Expect(globHelper.resolve).toHaveBeenCalledWith(path.replace(/\//g, sep));
+      Expect(globHelper.resolve).toHaveBeenCalledWith(resolve(path));
    }
 
    @TestCase("./*.js")


### PR DESCRIPTION
<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

# Description
Allow test specs to be in an absolute path. closes #420

<!-- Now, we've created a handy checklist before submitting your pull request to ensure it goes smoothly
      (we checked the first one for you because we know it's true) -->

# Checklist

- [x] I am an awesome developer and proud of my code
- [x] I added / updated / removed relevant unit or integration tests to prove my change works
- [x] I ran all tests using ```npm test``` to make sure everything else still works
- [x] I ran ```npm run review``` to ensure the code adheres to the repository standards
