### PR TITLE
Allow maps to be passed to the empty expectation

### DIFF
--- a/core/matchers/empty-matcher.ts
+++ b/core/matchers/empty-matcher.ts
@@ -18,19 +18,26 @@ export class EmptyMatcher<T> extends Matcher<T> {
     if (
       typeof this.actualValue !== "string" &&
       !Array.isArray(this.actualValue) &&
-      this.actualValue.constructor !== Object
+      this.actualValue.constructor !== Object &&
+      !(this.actualValue instanceof Map)
     ) {
       throw new TypeError(
-        "toBeEmpty requires value passed in to Expect to be an array, string or object literal"
+        "toBeEmpty requires value passed in to Expect to be an array, string, object literal or map"
       );
     }
 
-    const contents = (this.actualValue as any).length
-      ? this.actualValue
-      : Object.keys(this.actualValue);
+    if (this.actualValue instanceof Map) {
+      if ((this.actualValue.size === 0) !== this.shouldMatch) {
+        throw new EmptyMatchError(this.actualValue, this.shouldMatch);
+      }
+    } else {
+      const contents = (this.actualValue as any).length
+        ? this.actualValue
+        : Object.keys(this.actualValue);
 
-    if (((contents as any).length === 0) !== this.shouldMatch) {
-      throw new EmptyMatchError(this.actualValue, this.shouldMatch);
+      if (((contents as any).length === 0) !== this.shouldMatch) {
+        throw new EmptyMatchError(this.actualValue, this.shouldMatch);
+      }
     }
   }
 }

--- a/core/stringification/stringify.ts
+++ b/core/stringification/stringify.ts
@@ -5,6 +5,10 @@ export function stringify(data: any): string {
     return stringifyArray(data);
   }
 
+  if (data instanceof Map) {
+    return `Map<${data.size}>`;
+  }
+
   if (data === Any) {
     return "Anything";
   }

--- a/test/unit-tests/expect-tests/to-be-empty.spec.ts
+++ b/test/unit-tests/expect-tests/to-be-empty.spec.ts
@@ -4,7 +4,6 @@ import { EmptyMatchError } from "../../../core/errors/empty-match-error";
 class DummyClass {}
 
 export class ToBeEmptyTests {
-
   private readonly _typeErrorMessage: string =
     "toBeEmpty requires value passed in to Expect to be " +
     "an array, string or object literal";

--- a/test/unit-tests/expect-tests/to-be-empty.spec.ts
+++ b/test/unit-tests/expect-tests/to-be-empty.spec.ts
@@ -6,7 +6,7 @@ class DummyClass {}
 export class ToBeEmptyTests {
   private readonly _typeErrorMessage: string =
     "toBeEmpty requires value passed in to Expect to be " +
-    "an array, string or object literal";
+    "an array, string, object literal or map";
 
   @TestCase([])
   @TestCase([1])

--- a/test/unit-tests/expect-tests/to-be-empty.spec.ts
+++ b/test/unit-tests/expect-tests/to-be-empty.spec.ts
@@ -5,7 +5,7 @@ class DummyClass {}
 
 export class ToBeEmptyTests {
   // tslint:disable-next-line:max-line-length
-  private readonly _typeErrorMessage: string = "toBeEmpty requires value passed in to Expect to be an array, string or object literal";
+  private readonly _typeErrorMessage: string = "toBeEmpty requires value passed in to Expect to be an array, string, object literal or map";
 
   @TestCase([])
   @TestCase([1])
@@ -33,6 +33,17 @@ export class ToBeEmptyTests {
   @TestCase({})
   @TestCase({ a: true })
   public emptyShouldNotThrowTypeErrorForObjectLiterals(value: object) {
+    const expect = Expect(value);
+
+    Expect(() => expect.toBeEmpty()).not.toThrowError(
+      TypeError,
+      this._typeErrorMessage
+    );
+  }
+
+  @TestCase(new Map())
+  @TestCase(new Map([["keyOne", "valueOne"]]))
+  public emptyShouldNotThrowTypeErrorForMaps(value: Map<any, any>) {
     const expect = Expect(value);
 
     Expect(() => expect.toBeEmpty()).not.toThrowError(
@@ -168,6 +179,40 @@ export class ToBeEmptyTests {
   @Test()
   public notEmptyShouldNotThrowErrorForNonEmptyObject() {
     const expect = Expect({ a: true });
+
+    Expect(() => expect.not.toBeEmpty()).not.toThrow();
+  }
+
+  @Test()
+  public emptyShouldNotThrowErrorForEmptyMap() {
+    const expect = Expect(new Map());
+
+    Expect(() => expect.toBeEmpty()).not.toThrow();
+  }
+
+  @Test()
+  public emptyShouldThrowErrorForNonEmptyMap() {
+    const expect = Expect(new Map([["key", "value"]]));
+
+    Expect(() => expect.toBeEmpty()).toThrowError(
+      EmptyMatchError,
+      'Expected "Map<1>" to be empty.'
+    );
+  }
+
+  @Test()
+  public notEmptyShouldThrowErrorForEmptyMap() {
+    const expect = Expect(new Map());
+
+    Expect(() => expect.not.toBeEmpty()).toThrowError(
+      EmptyMatchError,
+      'Expected "Map<0>" not to be empty.'
+    );
+  }
+
+  @Test()
+  public notEmptyShouldNotThrowErrorForNonEmptyMap() {
+    const expect = Expect(new Map([["key", "value"]]));
 
     Expect(() => expect.not.toBeEmpty()).not.toThrow();
   }


### PR DESCRIPTION
<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

# Description

This allows `Map` to be used in the `toBeEmpty` expectation.

Closes #462 

# Checklist

- [x] I am an awesome developer and proud of my code
- [x] I added / updated / removed relevant unit or integration tests to prove my change works
- [ ] I ran all tests using ```npm test``` to make sure everything else still works
- [x] I ran ```npm run review``` to ensure the code adheres to the repository standards

<!-- Thanks again, and if you'd like to add any further information you can do so below -->

# Additional Information
I would love to get some feedback on the code inside the `empty-matcher` file, I do *not* like the nested if statements but I couldn't come up with a better way at the time.

As crazy as this sounds, `Map` keys can be anything, including another object. How should the `stringify` function handle them? I put a placeholder there to show the size/length of it, but I know that can be improved so it is less confusing.

Also, some reason the `npm test` command is failing on my Windows machine (I'm away from my usual development environment which is Linux) at the step `npm link && install-self`.