### PR TITLE
Allow TypeMatcher.thatMatches() to accept any object

### DIFF
--- a/core/spying/type-matcher.ts
+++ b/core/spying/type-matcher.ts
@@ -96,12 +96,6 @@ export class TypeMatcher<ExpectedType extends object> {
   }
 
   private _matchesObjectLiteral(properties: object): this {
-    if (properties.constructor !== Object) {
-      throw new TypeError(
-        "thatMatches requires value passed in to be an object literal"
-      );
-    }
-
     this._testers.push({
       stringify: () => `matches '${stringify(properties)}'`,
       test: (v: any) => {

--- a/test/unit-tests/spying/type-matcher/test.spec.ts
+++ b/test/unit-tests/spying/type-matcher/test.spec.ts
@@ -7,6 +7,10 @@ export class DerivedError extends Error {
   }
 }
 
+export class Testable<TA, TB> {
+  constructor(public a: TA, public b: TB) {}
+}
+
 export class TypeMatcherTestFunctionTests {
   @TestCase(0)
   @TestCase(1)
@@ -244,10 +248,6 @@ export class TypeMatcherTestFunctionTests {
       TypeError,
       "thatMatches requires none-null or non-undefined argument"
     );
-    Expect(() => sut.thatMatches(new Error("Something else"))).toThrowError(
-      TypeError,
-      "thatMatches requires value passed in to be an object literal"
-    );
     Expect(() => sut.thatMatches(3 as any)).toThrowError(
       Error,
       "Invalid arguments"
@@ -386,6 +386,16 @@ export class TypeMatcherTestFunctionTests {
     Expect(sut.stringify()).toBe(
       `Any Error and matches '${JSON.stringify(literal, replacer)}'`
     );
+  }
+
+  @TestCase(new Testable("a", "b"), new Testable("a", "b"))
+  @Test()
+  public thatMatchesShouldMatchAClassInstance(
+    instance: Testable<any, any>,
+    matcher: Testable<any, any>
+  ) {
+    const sut = new TypeMatcher(Testable).thatMatches(matcher);
+    Expect(sut.test(instance)).toBe(true);
   }
 
   @Test()


### PR DESCRIPTION
<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

# Description

Fixes #468
> Expect(spy).toHaveBeenCalledWith(object) should be able to match a class instance 

<!-- Now, we've created a handy checklist before submitting your pull request to ensure it goes smoothly
      (we checked the first one for you because we know it's true) -->

# Checklist

- [x] I am an awesome developer and proud of my code
- [x] I added / updated / removed relevant unit or integration tests to prove my change works
- [x] I ran all tests using ```npm test``` to make sure everything else still works
- [x] I ran ```npm run review``` to ensure the code adheres to the repository standards

<!-- Thanks again, and if you'd like to add any further information you can do so below -->

# Additional Information
The Gulp Integration tests are failing without an changes.
I have ignored this because I did not cause this issue.

```
> alsatian "./test/integration-tests/gulp/runner"
GulpIntegrationTests



D:\Github\alsatian\core\matchers\container-matcher.js:37
            throw new errors_1.ContentsMatchError(this.actualValue, expectedContent, this.shouldMatch);
            ^
ContentsMatchError: Expected "gulp[5416]: src\\node_contextify.cc:629: Assertion `args[1]->IsString()' failed.\r\n 1: node::DecodeWrite\r\n 2: node::DecodeWrite\r\n 3: uv_loop_fork\r\n 4: v8::internal::interpreter::BytecodeDecoder::Decode\r\n 5: v8::internal::RegExpImpl::Exec\r\n 6: v8::internal::RegExpImpl::Exec\r\n 7: v8::internal::RegExpImpl::Exec\r\n 8: 0000037F64184281\r\n" to contain "TAP version 13\n1..4\n# FIXTURE ToBeTests\nok 1 twoPlusTwoMakeFour\nok 2 twoPlusTwoDoNotMakeFive\nnot ok 3 twoPlusTwoDoNotMakeFour\n ---\n   message: \"Expected 4 not to be 4.\"\n   severity: fail\n   data:\n     got: 4\n     expect: 4\n ...\nnot ok 4 twoPlusTwoMakeFive\n ---\n   message: \"Expected 4 to be 5.\"\n   severity: fail\n   data:\n     got: 4\n     expect: 5\n ...\n".
```