### PR TITLE
Allow toEqual() to check Buffers for equality

### DIFF
--- a/core/matchers/matcher.ts
+++ b/core/matchers/matcher.ts
@@ -50,6 +50,11 @@ export class Matcher<T> {
 
     if (expectedValue instanceof TypeMatcher) {
       valueMatch = expectedValue.test(this._actualValue);
+    } else if (
+      Buffer.isBuffer(expectedValue) ||
+      Buffer.isBuffer(this._actualValue)
+    ) {
+      return this._checkBuffersAreEqual(expectedValue, this._actualValue);
     } else if (expectedValue instanceof Object) {
       valueMatch = this._checkObjectsAreDeepEqual(
         expectedValue,
@@ -102,6 +107,20 @@ export class Matcher<T> {
       (!this._actualValue && this.shouldMatch)
     ) {
       throw new TruthyMatchError(this._actualValue, this.shouldMatch);
+    }
+  }
+
+  private _checkBuffersAreEqual(_bufferA: any, _bufferB: any): boolean {
+    try {
+      const bufferA = Buffer.from(_bufferA);
+      const bufferB = Buffer.from(_bufferB);
+
+      return bufferA.equals(bufferB);
+    } catch (error) {
+      // if an error is thrown in the try, we can assume that either _bufferA or _bufferB were
+      // not of type string, Buffer, ArrayBuffer, Array, or Array-like Object, which are the only
+      // types convertible with Buffer.from(). It will throw a TypeError [ERR_INVALID_ARG_TYPE].
+      return false;
     }
   }
 

--- a/core/matchers/matcher.ts
+++ b/core/matchers/matcher.ts
@@ -112,8 +112,12 @@ export class Matcher<T> {
 
   private _checkBuffersAreEqual(_bufferA: any, _bufferB: any): boolean {
     try {
-      const bufferA = Buffer.from(_bufferA);
-      const bufferB = Buffer.from(_bufferB);
+      const bufferA = Buffer.isBuffer(_bufferA)
+        ? _bufferA
+        : Buffer.from(_bufferA);
+      const bufferB = Buffer.isBuffer(_bufferB)
+        ? _bufferB
+        : Buffer.from(_bufferB);
 
       return bufferA.equals(bufferB);
     } catch (error) {

--- a/core/matchers/matcher.ts
+++ b/core/matchers/matcher.ts
@@ -54,7 +54,7 @@ export class Matcher<T> {
       Buffer.isBuffer(expectedValue) ||
       Buffer.isBuffer(this._actualValue)
     ) {
-      return this._checkBuffersAreEqual(expectedValue, this._actualValue);
+      valueMatch = this._checkBuffersAreEqual(expectedValue, this._actualValue);
     } else if (expectedValue instanceof Object) {
       valueMatch = this._checkObjectsAreDeepEqual(
         expectedValue,

--- a/test/unit-tests/expect-tests/to-equal.spec.ts
+++ b/test/unit-tests/expect-tests/to-equal.spec.ts
@@ -291,6 +291,10 @@ export class ToEqualTests {
   @TestCase(Buffer.from([1, 2, 3]), undefined)
   @TestCase(Buffer.from([1, 2, 3]), 1)
   @TestCase(Buffer.from([1, 2, 3]), {})
+  @TestCase(Buffer.from([1, 2, 3]), Buffer.from([1, 2]))
+  @TestCase(Buffer.from([1, 2, 3]), [1, 2])
+  @TestCase(Buffer.from([1, 2, 3]), "")
+  @TestCase(Buffer.from([1, 2, 3]), { 0: 1, 1: 2, length: 2 })
   public throwsErrorsForNonMatchesWithBuffer(expected: any, actual: any) {
     const expect = Expect(actual);
 

--- a/test/unit-tests/expect-tests/to-equal.spec.ts
+++ b/test/unit-tests/expect-tests/to-equal.spec.ts
@@ -1,4 +1,10 @@
-import { Expect, Test, TestCase, Any } from "../../../core/alsatian-core";
+import {
+  Expect,
+  Test,
+  TestCase,
+  Any,
+  FocusTest
+} from "../../../core/alsatian-core";
 import { EqualMatchError } from "../../../core/errors/equal-match-error";
 import { stringify } from "../../../core/stringification";
 
@@ -224,6 +230,17 @@ export class ToEqualTests {
     Expect(() => expect.toEqual(expected)).not.toThrow();
   }
 
+  @FocusTest
+  @TestCase(Buffer.from([1, 2, 3]), Buffer.from([1, 2, 3]))
+  @TestCase(Buffer.from([1, 2, 3]), [1, 2, 3]) // Array
+  @TestCase(Buffer.from([1, 2, 3]), "") // String, "" was retrieved from Buffer.from([1, 2, 3]).toString()
+  @TestCase(Buffer.from([1, 2, 3]), { 0: 1, 1: 2, 2: 3, length: 3 }) // ArrayLike
+  public canMatchWithBuffer(expected: any, actual: any) {
+    const expect = Expect(actual);
+
+    Expect(() => expect.toEqual(expected)).not.toThrow();
+  }
+
   @TestCase(Any(Number), "something")
   @TestCase(Any(String), 42)
   @TestCase(Any(Object).thatMatches("property", 42), {
@@ -259,6 +276,51 @@ export class ToEqualTests {
       `to be equal to Any Object and matches '{"anotherProperty":"something"}'.`
   )
   public throwsCorrectErrorMessageForNonMatchesWithAny(
+    expected: any,
+    actual: any,
+    errorMessage: string
+  ) {
+    const expect = Expect(actual);
+
+    Expect(() => expect.toEqual(expected)).toThrowError(
+      EqualMatchError,
+      errorMessage
+    );
+  }
+
+  @FocusTest
+  @TestCase(Buffer.from([1, 2, 3]), null)
+  @TestCase(Buffer.from([1, 2, 3]), undefined)
+  @TestCase(Buffer.from([1, 2, 3]), 1)
+  @TestCase(Buffer.from([1, 2, 3]), {})
+  public throwsErrorsForNonMatchesWithBuffer(expected: any, actual: any) {
+    const expect = Expect(actual);
+
+    Expect(() => expect.toEqual(expected)).toThrow();
+  }
+
+  @FocusTest
+  @TestCase(
+    Buffer.from([1, 2, 3]),
+    null,
+    `Expected null to be equal to {"type":"Buffer","data":[1,2,3]}.`
+  )
+  @TestCase(
+    Buffer.from([1, 2, 3]),
+    undefined,
+    `Expected undefined to be equal to {"type":"Buffer","data":[1,2,3]}.`
+  )
+  @TestCase(
+    Buffer.from([1, 2, 3]),
+    1,
+    `Expected 1 to be equal to {"type":"Buffer","data":[1,2,3]}.`
+  )
+  @TestCase(
+    Buffer.from([1, 2, 3]),
+    {},
+    `Expected {} to be equal to {"type":"Buffer","data":[1,2,3]}.`
+  )
+  public throwsCorrectErrorMessageForNonMatchesWithBuffer(
     expected: any,
     actual: any,
     errorMessage: string

--- a/test/unit-tests/expect-tests/to-equal.spec.ts
+++ b/test/unit-tests/expect-tests/to-equal.spec.ts
@@ -230,17 +230,6 @@ export class ToEqualTests {
     Expect(() => expect.toEqual(expected)).not.toThrow();
   }
 
-  @FocusTest
-  @TestCase(Buffer.from([1, 2, 3]), Buffer.from([1, 2, 3]))
-  @TestCase(Buffer.from([1, 2, 3]), [1, 2, 3]) // Array
-  @TestCase(Buffer.from([1, 2, 3]), "") // String, "" was retrieved from Buffer.from([1, 2, 3]).toString()
-  @TestCase(Buffer.from([1, 2, 3]), { 0: 1, 1: 2, 2: 3, length: 3 }) // ArrayLike
-  public canMatchWithBuffer(expected: any, actual: any) {
-    const expect = Expect(actual);
-
-    Expect(() => expect.toEqual(expected)).not.toThrow();
-  }
-
   @TestCase(Any(Number), "something")
   @TestCase(Any(String), 42)
   @TestCase(Any(Object).thatMatches("property", 42), {
@@ -288,7 +277,16 @@ export class ToEqualTests {
     );
   }
 
-  @FocusTest
+  @TestCase(Buffer.from([1, 2, 3]), Buffer.from([1, 2, 3]))
+  @TestCase(Buffer.from([1, 2, 3]), [1, 2, 3]) // Array
+  @TestCase(Buffer.from([1, 2, 3]), "") // String, "" was retrieved from Buffer.from([1, 2, 3]).toString()
+  @TestCase(Buffer.from([1, 2, 3]), { 0: 1, 1: 2, 2: 3, length: 3 }) // ArrayLike
+  public canMatchWithBuffer(expected: any, actual: any) {
+    const expect = Expect(actual);
+
+    Expect(() => expect.toEqual(expected)).not.toThrow();
+  }
+
   @TestCase(Buffer.from([1, 2, 3]), null)
   @TestCase(Buffer.from([1, 2, 3]), undefined)
   @TestCase(Buffer.from([1, 2, 3]), 1)
@@ -299,7 +297,6 @@ export class ToEqualTests {
     Expect(() => expect.toEqual(expected)).toThrow();
   }
 
-  @FocusTest
   @TestCase(
     Buffer.from([1, 2, 3]),
     null,


### PR DESCRIPTION
<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

# Description

If either `expectedValue` or `actualValue` are of type `Buffer`, they will be converted to a new `Buffer`, and compared using `Buffer.equals(Buffer)`.

Fixes #465

<!-- Now, we've created a handy checklist before submitting your pull request to ensure it goes smoothly
      (we checked the first one for you because we know it's true) -->

# Checklist

- [x] I am an awesome developer and proud of my code
- [x] I added / updated / removed relevant unit or integration tests to prove my change works
- [x] I ran all tests using ```npm test``` to make sure everything else still works
- [x] I ran ```npm run review``` to ensure the code adheres to the repository standards

<!-- Thanks again, and if you'd like to add any further information you can do so below -->

# Additional Information
