### PR TITLE
refactor setup and teardown decorators

### DIFF
--- a/core/decorators/async-setup-decorator.ts
+++ b/core/decorators/async-setup-decorator.ts
@@ -1,29 +1,5 @@
-import "reflect-metadata";
-import { ISetupTeardownMetadata } from "./_interfaces";
 import { SETUP } from "./_metadata-keys";
-import { Unused } from "../unused";
+import { createSetupTeardownDecorator } from "./create-setup-teardown-decorator";
 
-export function AsyncSetup(
-  target: object,
-  decoratedPropertyKey: string,
-  descriptor?: TypedPropertyDescriptor<() => any>
-) {
-  Unused(descriptor);
-
-  let setupFunctions: Array<ISetupTeardownMetadata> = Reflect.getMetadata(
-    SETUP,
-    target
-  );
-
-  if (!setupFunctions) {
-    setupFunctions = [];
-  }
-
-  setupFunctions.push({
-    isAsync: true,
-    propertyKey: decoratedPropertyKey
-  });
-
-  // mark as setup test method
-  Reflect.defineMetadata(SETUP, setupFunctions, target);
-}
+// tslint:disable-next-line:variable-name
+export const AsyncSetup = createSetupTeardownDecorator(SETUP, true);

--- a/core/decorators/async-setup-fixture-decorator.ts
+++ b/core/decorators/async-setup-fixture-decorator.ts
@@ -1,28 +1,8 @@
-import "reflect-metadata";
-import { ISetupTeardownMetadata } from "./_interfaces";
-import { SETUP_FIXTURE } from "./_metadata-keys";
-import { Unused } from "../unused";
+import { SETUP_FIXTURE, SETUP } from "./_metadata-keys";
+import { createSetupTeardownDecorator } from "./create-setup-teardown-decorator";
 
-export function AsyncSetupFixture(
-  target: object,
-  decoratedPropertyKey: string,
-  descriptor?: TypedPropertyDescriptor<() => any>
-) {
-  Unused(descriptor);
-
-  let setupFixtureFunctions: Array<
-    ISetupTeardownMetadata
-  > = Reflect.getMetadata(SETUP_FIXTURE, target);
-
-  if (!setupFixtureFunctions) {
-    setupFixtureFunctions = [];
-  }
-
-  setupFixtureFunctions.push({
-    isAsync: true,
-    propertyKey: decoratedPropertyKey
-  });
-
-  // mark as setup test method
-  Reflect.defineMetadata(SETUP_FIXTURE, setupFixtureFunctions, target);
-}
+// tslint:disable-next-line:variable-name
+export const AsyncSetupFixture = createSetupTeardownDecorator(
+  SETUP_FIXTURE,
+  true
+);

--- a/core/decorators/async-teardown-decorator.ts
+++ b/core/decorators/async-teardown-decorator.ts
@@ -1,29 +1,5 @@
-import "reflect-metadata";
-import { ISetupTeardownMetadata } from "./_interfaces";
 import { TEARDOWN } from "./_metadata-keys";
-import { Unused } from "../unused";
+import { createSetupTeardownDecorator } from "./create-setup-teardown-decorator";
 
-export function AsyncTeardown(
-  target: object,
-  decoratedPropertyKey: string,
-  descriptor?: TypedPropertyDescriptor<() => any>
-) {
-  Unused(descriptor);
-
-  let teardownFunctions: Array<ISetupTeardownMetadata> = Reflect.getMetadata(
-    TEARDOWN,
-    target
-  );
-
-  if (!teardownFunctions) {
-    teardownFunctions = [];
-  }
-
-  teardownFunctions.push({
-    isAsync: true,
-    propertyKey: decoratedPropertyKey
-  });
-
-  // mark as setup test method
-  Reflect.defineMetadata(TEARDOWN, teardownFunctions, target);
-}
+// tslint:disable-next-line:variable-name
+export const AsyncTeardown = createSetupTeardownDecorator(TEARDOWN, true);

--- a/core/decorators/async-teardown-fixture-decorator.ts
+++ b/core/decorators/async-teardown-fixture-decorator.ts
@@ -1,28 +1,8 @@
-import "reflect-metadata";
-import { ISetupTeardownMetadata } from "./_interfaces";
 import { TEARDOWN_FIXTURE } from "./_metadata-keys";
-import { Unused } from "../unused";
+import { createSetupTeardownDecorator } from "./create-setup-teardown-decorator";
 
-export function AsyncTeardownFixture(
-  target: object,
-  decoratedPropertyKey: string,
-  descriptor?: TypedPropertyDescriptor<() => any>
-) {
-  Unused(descriptor);
-
-  let teardownFixtureFunctions: Array<
-    ISetupTeardownMetadata
-  > = Reflect.getMetadata(TEARDOWN_FIXTURE, target);
-
-  if (!teardownFixtureFunctions) {
-    teardownFixtureFunctions = [];
-  }
-
-  teardownFixtureFunctions.push({
-    isAsync: true,
-    propertyKey: decoratedPropertyKey
-  });
-
-  // mark as teardown test method
-  Reflect.defineMetadata(TEARDOWN_FIXTURE, teardownFixtureFunctions, target);
-}
+// tslint:disable-next-line:variable-name
+export const AsyncTeardownFixture = createSetupTeardownDecorator(
+  TEARDOWN_FIXTURE,
+  true
+);

--- a/core/decorators/create-setup-teardown-decorator.ts
+++ b/core/decorators/create-setup-teardown-decorator.ts
@@ -1,0 +1,23 @@
+import "reflect-metadata";
+import { ISetupTeardownMetadata } from "./_interfaces";
+
+export function createSetupTeardownDecorator(
+  metadataDescription: string,
+  isAsync: boolean
+) {
+  return (
+    target: object,
+    decoratedPropertyKey: string,
+    descriptor?: TypedPropertyDescriptor<() => any>
+  ) => {
+    const functions: Array<ISetupTeardownMetadata> =
+      Reflect.getMetadata(metadataDescription, target) || [];
+
+    functions.push({
+      isAsync,
+      propertyKey: decoratedPropertyKey
+    });
+
+    Reflect.defineMetadata(metadataDescription, functions, target);
+  };
+}

--- a/core/decorators/setup-decorator.ts
+++ b/core/decorators/setup-decorator.ts
@@ -1,29 +1,5 @@
-import "reflect-metadata";
-import { ISetupTeardownMetadata } from "./_interfaces";
 import { SETUP } from "./_metadata-keys";
-import { Unused } from "../unused";
+import { createSetupTeardownDecorator } from "./create-setup-teardown-decorator";
 
-export function Setup(
-  target: object,
-  decoratedPropertyKey: string,
-  descriptor?: TypedPropertyDescriptor<() => any>
-) {
-  Unused(descriptor);
-
-  let setupFunctions: Array<ISetupTeardownMetadata> = Reflect.getMetadata(
-    SETUP,
-    target
-  );
-
-  if (!setupFunctions) {
-    setupFunctions = [];
-  }
-
-  setupFunctions.push({
-    isAsync: false,
-    propertyKey: decoratedPropertyKey
-  });
-
-  // mark as setup test method
-  Reflect.defineMetadata(SETUP, setupFunctions, target);
-}
+// tslint:disable-next-line:variable-name
+export const Setup = createSetupTeardownDecorator(SETUP, false);

--- a/core/decorators/setup-fixture-decorator.ts
+++ b/core/decorators/setup-fixture-decorator.ts
@@ -1,28 +1,5 @@
-import "reflect-metadata";
-import { ISetupTeardownMetadata } from "./_interfaces";
 import { SETUP_FIXTURE } from "./_metadata-keys";
-import { Unused } from "../unused";
+import { createSetupTeardownDecorator } from "./create-setup-teardown-decorator";
 
-export function SetupFixture(
-  target: object,
-  decoratedPropertyKey: string,
-  descriptor?: TypedPropertyDescriptor<() => any>
-) {
-  Unused(descriptor);
-
-  let setupFixtureFunctions: Array<
-    ISetupTeardownMetadata
-  > = Reflect.getMetadata(SETUP_FIXTURE, target);
-
-  if (!setupFixtureFunctions) {
-    setupFixtureFunctions = [];
-  }
-
-  setupFixtureFunctions.push({
-    isAsync: false,
-    propertyKey: decoratedPropertyKey
-  });
-
-  // mark as setup test method
-  Reflect.defineMetadata(SETUP_FIXTURE, setupFixtureFunctions, target);
-}
+// tslint:disable-next-line:variable-name
+export const SetupFixture = createSetupTeardownDecorator(SETUP_FIXTURE, false);

--- a/core/decorators/teardown-decorator.ts
+++ b/core/decorators/teardown-decorator.ts
@@ -1,29 +1,5 @@
-import "reflect-metadata";
-import { ISetupTeardownMetadata } from "./_interfaces";
 import { TEARDOWN } from "./_metadata-keys";
-import { Unused } from "../unused";
+import { createSetupTeardownDecorator } from "./create-setup-teardown-decorator";
 
-export function Teardown(
-  target: object,
-  decoratedPropertyKey: string,
-  descriptor?: TypedPropertyDescriptor<() => any>
-) {
-  Unused(descriptor);
-
-  let teardownFunctions: Array<ISetupTeardownMetadata> = Reflect.getMetadata(
-    TEARDOWN,
-    target
-  );
-
-  if (!teardownFunctions) {
-    teardownFunctions = [];
-  }
-
-  teardownFunctions.push({
-    isAsync: false,
-    propertyKey: decoratedPropertyKey
-  });
-
-  // mark as teardown test method
-  Reflect.defineMetadata(TEARDOWN, teardownFunctions, target);
-}
+// tslint:disable-next-line:variable-name
+export const Teardown = createSetupTeardownDecorator(TEARDOWN, false);

--- a/core/decorators/teardown-fixture-decorator.ts
+++ b/core/decorators/teardown-fixture-decorator.ts
@@ -1,28 +1,8 @@
-import "reflect-metadata";
-import { ISetupTeardownMetadata } from "./_interfaces";
 import { TEARDOWN_FIXTURE } from "./_metadata-keys";
-import { Unused } from "../unused";
+import { createSetupTeardownDecorator } from "./create-setup-teardown-decorator";
 
-export function TeardownFixture(
-  target: object,
-  decoratedPropertyKey: string,
-  descriptor?: TypedPropertyDescriptor<() => any>
-) {
-  Unused(descriptor);
-
-  let teardownFixtureFunctions: Array<
-    ISetupTeardownMetadata
-  > = Reflect.getMetadata(TEARDOWN_FIXTURE, target);
-
-  if (!teardownFixtureFunctions) {
-    teardownFixtureFunctions = [];
-  }
-
-  teardownFixtureFunctions.push({
-    isAsync: false,
-    propertyKey: decoratedPropertyKey
-  });
-
-  // mark as teardown test method
-  Reflect.defineMetadata(TEARDOWN_FIXTURE, teardownFixtureFunctions, target);
-}
+// tslint:disable-next-line:variable-name
+export const TeardownFixture = createSetupTeardownDecorator(
+  TEARDOWN_FIXTURE,
+  false
+);

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "prettier": "^1.10.2",
     "rimraf": "^2.5.4",
     "selenium-webdriver": "^3.0.1",
-    "ts-node": "^4.0.0",
     "ts-node": "^3.3.0",
     "tslint": "^5.9.1",
     "tslint-plugin-prettier": "^1.3.0",


### PR DESCRIPTION
<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

# Description

Refactors `Setup` and `Teardown` decorators to use common code.

<!-- Now, we've created a handy checklist before submitting your pull request to ensure it goes smoothly
      (we checked the first one for you because we know it's true) -->

# Checklist

- [x] I am an awesome developer and proud of my code
- [x] I added / updated / removed relevant unit or integration tests to prove my change works
- [x] I ran all tests using ```npm test``` to make sure everything else still works
- [x] I ran ```npm run review``` to ensure the code adheres to the repository standards