### PR TITLE
fix(): Admit ts files as input (#434)

### DIFF
--- a/cli/alsatian-cli.ts
+++ b/cli/alsatian-cli.ts
@@ -1,6 +1,5 @@
 #! /usr/bin/env node
-// tslint:disable-next-line
-require('ts-node/register');
+import "ts-node/register";
 
 import { AlsatianCliOptions } from "./alsatian-cli-options";
 import { CliTestRunner } from "./cli-test-runner";

--- a/cli/alsatian-cli.ts
+++ b/cli/alsatian-cli.ts
@@ -1,4 +1,6 @@
 #! /usr/bin/env node
+// tslint:disable-next-line
+require('ts-node/register');
 
 import { AlsatianCliOptions } from "./alsatian-cli-options";
 import { CliTestRunner } from "./cli-test-runner";

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "prettier": "^1.10.2",
     "rimraf": "^2.5.4",
     "selenium-webdriver": "^3.0.1",
-    "ts-node": "^7.0.0",
     "tslint": "^5.9.1",
     "tslint-plugin-prettier": "^1.3.0",
     "typescript": "^2.0.3"
@@ -114,6 +113,7 @@
     "extendo-error": "^1.0.1",
     "glob": "^7.0.3",
     "reflect-metadata": "^0.1.3",
-    "tap-bark": "1.0.0"
+    "tap-bark": "1.0.0",
+    "ts-node": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alsatian",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "TypeScript and JavaScript testing framework for beautiful and readable tests",
   "author": "James Richford <=> (=)",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alsatian",
-  "version": "2.3.1",
+  "version": "2.3.0",
   "description": "TypeScript and JavaScript testing framework for beautiful and readable tests",
   "author": "James Richford <=> (=)",
   "contributors": [


### PR DESCRIPTION
<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

# Description

Solves #434 so we can use `.ts` files as input via a simple `require(ts-node/register)`

<!-- Now, we've created a handy checklist before submitting your pull request to ensure it goes smoothly
      (we checked the first one for you because we know it's true) -->

# Checklist

- [x] I am an awesome developer and proud of my code
- [ ] I added / updated / removed relevant unit or integration tests to prove my change works
- [x] I ran all tests using ```npm test``` to make sure everything else still works
and `npm test` fails the same way as in current master branch, with ```
/mnt/projects/libs/alsatian/core/matchers/container-matcher.js:37
            throw new errors_1.ContentsMatchError(this.actualValue, expectedContent, this.shouldMatch);
            ^
ContentsMatchError: Expected "fs.js:25\n'use strict';\n^\n\nReferenceError: internalBinding is not defined\n    at fs.js:25:1\n.... ```

- [ ] I ran ```npm run review``` to ensure the code adheres to the repository standards


<!-- Thanks again, and if you'd like to add any further information you can do so below -->

# Additional Information
