### PR TITLE
Test and fix to CLI termination delay when a timeout is set

### DIFF
--- a/core/running/test-item.ts
+++ b/core/running/test-item.ts
@@ -1,7 +1,7 @@
-import { ITest, ITestCase, ITestFixture } from '../_interfaces';
-import { METADATA_KEYS } from '../alsatian-core';
-import { ISetupTeardownMetadata } from '../decorators/_interfaces';
-import { TestTimeoutError } from '../errors';
+import { ITest, ITestCase, ITestFixture } from "../_interfaces";
+import { METADATA_KEYS } from "../alsatian-core";
+import { ISetupTeardownMetadata } from "../decorators/_interfaces";
+import { TestTimeoutError } from "../errors";
 
 export class TestItem {
   private _testCase: ITestCase;
@@ -19,17 +19,21 @@ export class TestItem {
     return this._testFixture;
   }
 
-  public constructor(testFixture: ITestFixture, test: ITest, testCase: ITestCase) {
+  public constructor(
+    testFixture: ITestFixture,
+    test: ITest,
+    testCase: ITestCase
+  ) {
     if (testFixture === null || testFixture === undefined) {
-      throw new TypeError('testFixture must not be null or undefined.');
+      throw new TypeError("testFixture must not be null or undefined.");
     }
 
     if (test === null || test === undefined) {
-      throw new TypeError('test must not be null or undefined.');
+      throw new TypeError("test must not be null or undefined.");
     }
 
     if (testCase === null || testCase === undefined) {
-      throw new TypeError('testCase must not be null or undefined.');
+      throw new TypeError("testCase must not be null or undefined.");
     }
 
     this._testFixture = testFixture;
@@ -100,9 +104,13 @@ export class TestItem {
 
   private async _runFunctionFromMetadata(funcMetadata: ISetupTeardownMetadata) {
     if (funcMetadata.isAsync) {
-      await this._testFixture.fixture[funcMetadata.propertyKey].call(this.testFixture.fixture);
+      await this._testFixture.fixture[funcMetadata.propertyKey].call(
+        this.testFixture.fixture
+      );
     } else {
-      this._testFixture.fixture[funcMetadata.propertyKey].call(this.testFixture.fixture);
+      this._testFixture.fixture[funcMetadata.propertyKey].call(
+        this.testFixture.fixture
+      );
     }
   }
 }

--- a/core/running/test-item.ts
+++ b/core/running/test-item.ts
@@ -1,7 +1,7 @@
-import { ITest, ITestCase, ITestFixture } from "../_interfaces";
-import { METADATA_KEYS } from "../alsatian-core";
-import { ISetupTeardownMetadata } from "../decorators/_interfaces";
-import { TestTimeoutError } from "../errors";
+import { ITest, ITestCase, ITestFixture } from '../_interfaces';
+import { METADATA_KEYS } from '../alsatian-core';
+import { ISetupTeardownMetadata } from '../decorators/_interfaces';
+import { TestTimeoutError } from '../errors';
 
 export class TestItem {
   private _testCase: ITestCase;
@@ -19,21 +19,17 @@ export class TestItem {
     return this._testFixture;
   }
 
-  public constructor(
-    testFixture: ITestFixture,
-    test: ITest,
-    testCase: ITestCase
-  ) {
+  public constructor(testFixture: ITestFixture, test: ITest, testCase: ITestCase) {
     if (testFixture === null || testFixture === undefined) {
-      throw new TypeError("testFixture must not be null or undefined.");
+      throw new TypeError('testFixture must not be null or undefined.');
     }
 
     if (test === null || test === undefined) {
-      throw new TypeError("test must not be null or undefined.");
+      throw new TypeError('test must not be null or undefined.');
     }
 
     if (testCase === null || testCase === undefined) {
-      throw new TypeError("testCase must not be null or undefined.");
+      throw new TypeError('testCase must not be null or undefined.');
     }
 
     this._testFixture = testFixture;
@@ -58,7 +54,7 @@ export class TestItem {
 
   private async _runTest(timeout: number) {
     return new Promise<any>((resolve, reject) => {
-      setTimeout(() => {
+      const to = setTimeout(() => {
         reject(new TestTimeoutError(timeout));
       }, timeout);
 
@@ -70,6 +66,7 @@ export class TestItem {
         this._execute();
         resolve();
       }
+      clearTimeout(to);
     });
   }
 
@@ -103,13 +100,9 @@ export class TestItem {
 
   private async _runFunctionFromMetadata(funcMetadata: ISetupTeardownMetadata) {
     if (funcMetadata.isAsync) {
-      await this._testFixture.fixture[funcMetadata.propertyKey].call(
-        this.testFixture.fixture
-      );
+      await this._testFixture.fixture[funcMetadata.propertyKey].call(this.testFixture.fixture);
     } else {
-      this._testFixture.fixture[funcMetadata.propertyKey].call(
-        this.testFixture.fixture
-      );
+      this._testFixture.fixture[funcMetadata.propertyKey].call(this.testFixture.fixture);
     }
   }
 }

--- a/test/integration-tests/cli/runner.ts
+++ b/test/integration-tests/cli/runner.ts
@@ -1,18 +1,27 @@
-import * as child from 'child_process';
-import * as FileSystem from 'fs';
-import * as path from 'path';
-import { AsyncTest, Expect, TestCase, Timeout } from '../../../core/alsatian-core';
+import * as child from "child_process";
+import * as FileSystem from "fs";
+import * as path from "path";
+import {
+  AsyncTest,
+  Expect,
+  TestCase,
+  Timeout
+} from "../../../core/alsatian-core";
 
 export class CliIntegrationTests {
   @AsyncTest()
   public async tapWithTimeoutDoesNotDelayShutdown() {
     const result = child.exec(
-      `alsatian ` + `./test/integration-tests/cli/single.spec.js` + `--tap` + `--timeout` + `9999`
+      `alsatian ` +
+        `./test/integration-tests/cli/single.spec.js` +
+        `--tap` +
+        `--timeout` +
+        `9999`
     );
     // This does not test aything other than it will timeout, because
-    // it's awaiting the timeouts set in test-item
+    // it's awaiting the timeouts set in test-item (for 9999 seconds)
     return new Promise<void>((resolve, reject) => {
-      result.on('close', (code: number) => {
+      result.on("close", (code: number) => {
         resolve();
       });
     });

--- a/test/integration-tests/cli/runner.ts
+++ b/test/integration-tests/cli/runner.ts
@@ -1,68 +1,18 @@
-import * as child from "child_process";
-import * as FileSystem from "fs";
-import * as path from "path";
-import {
-  AsyncTest,
-  Expect,
-  TestCase,
-  Timeout
-} from "../../../core/alsatian-core";
+import * as child from 'child_process';
+import * as FileSystem from 'fs';
+import * as path from 'path';
+import { AsyncTest, Expect, TestCase, Timeout } from '../../../core/alsatian-core';
 
 export class CliIntegrationTests {
-  @TestCase("to-be")
-  @TestCase("to-throw")
   @AsyncTest()
-  @Timeout(5000)
-  public toBeExpectations(expectationTestName: string) {
+  public async tapWithTimeoutDoesNotDelayShutdown() {
     const result = child.exec(
-      `alsatian ` +
-        `./test/integration-tests/test-sets/expectations/${expectationTestName}.spec.js` +
-        ` --tap`
+      `alsatian ` + `./test/integration-tests/cli/single.spec.js` + `--tap` + `--timeout` + `9999`
     );
-
-    let consoleOutput = "";
-
-    result.stdout.on("data", (data: string) => (consoleOutput += data));
-    result.stderr.on("data", (data: string) => (consoleOutput += data));
-
-    const expectedOutput = FileSystem.readFileSync(
-      `./test/integration-tests/expected-output/` +
-        `expectations/${expectationTestName}.txt`
-    ).toString();
-
+    // This does not test aything other than it will timeout, because
+    // it's awaiting the timeouts set in test-item
     return new Promise<void>((resolve, reject) => {
-      result.on("close", (code: number) => {
-        Expect(consoleOutput).toBe(expectedOutput.replace(/\r/g, ""));
-        resolve();
-      });
-    });
-  }
-
-  @TestCase("async-test")
-  @TestCase("setup")
-  @TestCase("teardown")
-  @TestCase("case-arguments")
-  @AsyncTest()
-  @Timeout(5000)
-  public syntaxTests(syntaxTestName: string) {
-    const result = child.exec(
-      `alsatian ` +
-        `./test/integration-tests/test-sets/test-syntax/${syntaxTestName}*.spec.js ` +
-        `--tap`
-    );
-
-    let consoleOutput = "";
-
-    result.stdout.on("data", (data: string) => (consoleOutput += data));
-    result.stderr.on("data", (data: string) => (consoleOutput += data));
-
-    const expectedOutput = FileSystem.readFileSync(
-      `./test/integration-tests/expected-output/test-syntax/${syntaxTestName}.txt`
-    ).toString();
-
-    return new Promise<void>((resolve, reject) => {
-      result.on("close", (code: number) => {
-        Expect(consoleOutput).toBe(expectedOutput.replace(/\r/g, ""));
+      result.on('close', (code: number) => {
         resolve();
       });
     });

--- a/test/integration-tests/cli/single.spec.ts
+++ b/test/integration-tests/cli/single.spec.ts
@@ -1,0 +1,8 @@
+import { Expect, Test } from 'alsatian';
+
+export class SingleTest {
+  @Test()
+  public twoPlusTwoMakeFour() {
+    Expect(2 + 2).toBe(4);
+  }
+}

--- a/test/integration-tests/cli/single.spec.ts
+++ b/test/integration-tests/cli/single.spec.ts
@@ -1,4 +1,4 @@
-import { Expect, Test } from 'alsatian';
+import { Expect, Test } from "alsatian";
 
 export class SingleTest {
   @Test()


### PR DESCRIPTION
<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

Thanks for building this, jest was driving me nuts.

# Description

*Issue:*
When using alsatian with a timeout (`--timeout`), the CLI always wait for all those timeouts to expire before completing. With the default timeout (500ms) it is not very noticeable, but with a long timeout it's very noticeable.

So for example, say I use a 10s timeout, here is what happens:
- run alsatian
- the tests run and complete
- Have to wait 10s for the alsatian process to complete.

*Fix:*
I fixed it by clearing the timeout upon test completion (in test-item.ts), that's probably enough.

Not sure my test is all hat great or in the right place, but you get the idea. Feel free to tweak or close this and redo, as you prefer.

# Checklist

- [~] I am an awesome developer and proud of my code
- [X] I added / updated / removed relevant unit or integration tests to prove my change works
- [X] I ran all tests using ```npm test``` to make sure everything else still works
- [ X] I ran ```npm run review``` to ensure the code adheres to the repository standards

<!-- Thanks again, and if you'd like to add any further information you can do so below -->

# Additional Information
