### PR TITLE
Clear the timeouts when tests are complete so the CLI exits right away.

### DIFF
--- a/core/running/test-item.ts
+++ b/core/running/test-item.ts
@@ -58,7 +58,7 @@ export class TestItem {
 
   private async _runTest(timeout: number) {
     return new Promise<any>((resolve, reject) => {
-      setTimeout(() => {
+      const to = setTimeout(() => {
         reject(new TestTimeoutError(timeout));
       }, timeout);
 
@@ -70,6 +70,7 @@ export class TestItem {
         this._execute();
         resolve();
       }
+      clearTimeout(to);
     });
   }
 

--- a/test/integration-tests/cli/runner.ts
+++ b/test/integration-tests/cli/runner.ts
@@ -67,4 +67,22 @@ export class CliIntegrationTests {
       });
     });
   }
+
+  @AsyncTest()
+  public async tapWithTimeoutDoesNotDelayShutdown() {
+    const result = child.exec(
+      `alsatian ` +
+        `./test/integration-tests/cli/single.spec.js` +
+        `--tap` +
+        `--timeout` +
+        `9999`
+    );
+    // This does not test aything other than it will timeout, because
+    // it's awaiting the timeouts set in test-item (for 9999 seconds)
+    return new Promise<void>((resolve, reject) => {
+      result.on("close", (code: number) => {
+        resolve();
+      });
+    });
+  }
 }

--- a/test/integration-tests/single.spec.ts
+++ b/test/integration-tests/single.spec.ts
@@ -1,0 +1,8 @@
+import { Expect, Test } from "alsatian";
+
+export class SingleTest {
+  @Test()
+  public twoPlusTwoMakeFour() {
+    Expect(2 + 2).toBe(4);
+  }
+}


### PR DESCRIPTION
<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

Thanks for building this, jest was driving me nuts.

# Description

*Issue:*
When using alsatian with a timeout (`--timeout`), the CLI always wait for all those timeouts to expire before completing. With the default timeout (500ms) it is not very noticeable, but with a long timeout it's very noticeable.

So for example, say I use a 10s timeout, here is what happens:
- run alsatian
- the tests run and complete
- Have to wait 10s for the alsatian process to complete.

*Fix:*
I fixed it by clearing the timeout upon test completion (in test-item.ts), that's probably enough.

Not sure my test is all hat great or in the right place, but you get the idea. Feel free to tweak or close this and redo, as you prefer.

# Checklist

- [~] I am an awesome developer and proud of my code
- [X] I added / updated / removed relevant unit or integration tests to prove my change works
- [X] I ran all tests using ```npm test``` to make sure everything else still works
- [X] I ran ```npm run review``` to ensure the code adheres to the repository standards

<!-- Thanks again, and if you'd like to add any further information you can do so below -->

# Additional Information
