### PR TITLE
Fix #544: Stringify values before diffing

### DIFF
--- a/packages/alsatian/core/matchers/diff.ts
+++ b/packages/alsatian/core/matchers/diff.ts
@@ -112,6 +112,14 @@ function buildDiffProp(diffInfo: deepDiff.IDiff, value: any, padding: string) {
 	}`;
 }
 
+function safeToString(val: any) {
+	if (val && val.toString) {
+		return val.toString();
+	}
+
+	return String(val).toString();
+}
+
 function stringifyDiffProp(diffInfo: deepDiff.IDiff, padding: string) {
 	if (diffInfo.kind === "N") {
 		return chalk.green(
@@ -122,7 +130,7 @@ function stringifyDiffProp(diffInfo: deepDiff.IDiff, padding: string) {
 	} else if (diffInfo.kind === "E") {
 		return `  ${buildDiffProp(
 			diffInfo,
-			diffString(diffInfo.lhs, diffInfo.rhs),
+			diffString(safeToString(diffInfo.lhs), safeToString(diffInfo.rhs)),
 			padding
 		)}`;
 	}

--- a/packages/alsatian/test/integration-tests/cli/runner.ts
+++ b/packages/alsatian/test/integration-tests/cli/runner.ts
@@ -10,6 +10,7 @@ import {
 
 export class CliIntegrationTests {
 	@TestCase("to-be")
+	@TestCase("to-equal")
 	@TestCase("to-throw")
 	@AsyncTest()
 	@Timeout(5000)

--- a/packages/alsatian/test/integration-tests/expected-output/expectations/to-equal.txt
+++ b/packages/alsatian/test/integration-tests/expected-output/expectations/to-equal.txt
@@ -9,5 +9,8 @@ not ok 1 ToEqualTests > onObjectWithNumericDifference
    got: '{"price":159.99999999999997}'
    expect: '{"price":160}'
    details:
-     diff: "{\n    price: \"1\e[31m60\e[39m\e[32m59.99999999999997\e[39m\"\n}"
+     diff: |-
+       {
+           price: "16059.99999999999997"
+       }
  ...

--- a/packages/alsatian/test/integration-tests/expected-output/expectations/to-equal.txt
+++ b/packages/alsatian/test/integration-tests/expected-output/expectations/to-equal.txt
@@ -1,0 +1,13 @@
+TAP version 13
+1..1
+# FIXTURE ToEqualTests
+not ok 1 ToEqualTests > onObjectWithNumericDifference
+ ---
+ message: Expected objects to be equal
+ severity: fail
+ data:
+   got: '{"price":159.99999999999997}'
+   expect: '{"price":160}'
+   details:
+     diff: "{\n    price: \"1\e[31m60\e[39m\e[32m59.99999999999997\e[39m\"\n}"
+ ...

--- a/packages/alsatian/test/integration-tests/test-sets/expectations/to-equal.spec.ts
+++ b/packages/alsatian/test/integration-tests/test-sets/expectations/to-equal.spec.ts
@@ -1,0 +1,16 @@
+import { Expect, Test } from "alsatian";
+
+export class ToEqualTests {
+	@Test()
+	public onObjectWithNumericDifference() {
+        const expected = {
+            price: 160
+        };
+
+        const result = {
+            price: 159.99999999999997
+        };
+
+        Expect(result).toEqual(expected);
+	}
+}

--- a/packages/alsatian/test/integration-tests/test-sets/expectations/to-equal.spec.ts
+++ b/packages/alsatian/test/integration-tests/test-sets/expectations/to-equal.spec.ts
@@ -3,14 +3,14 @@ import { Expect, Test } from "alsatian";
 export class ToEqualTests {
 	@Test()
 	public onObjectWithNumericDifference() {
-        const expected = {
-            price: 160
-        };
+		const expected = {
+			price: 160
+		};
 
-        const result = {
-            price: 159.99999999999997
-        };
+		const result = {
+			price: 159.99999999999997
+		};
 
-        Expect(result).toEqual(expected);
+		Expect(result).toEqual(expected);
 	}
 }

--- a/packages/alsatian/test/unit-tests/matchers/diff.spec.ts
+++ b/packages/alsatian/test/unit-tests/matchers/diff.spec.ts
@@ -119,4 +119,11 @@ export class DiffingFunctionTests {
 			"{\n" + chalk.green(`+   an: {"extra":"object"}`) + "\n}"
 		);
 	}
+
+	@Test()
+	public objectWithNumeric() {
+		Expect(diff({ a: 123 }, { a: 456 })).toBe(
+			`{\n    a: "${chalk.red("123")}${chalk.green("456")}"\n}`
+		);
+	}
 }


### PR DESCRIPTION
# Description

Stringify values before passing them to `diff` to prevent error

# Checklist

- [x] I am an awesome developer and proud of my code
- [x] I added / updated / removed relevant unit or integration tests to prove my change works
- [x] I ran all tests using ```npm test``` to make sure everything else still works
- [ ] I ran ```npm run review``` to ensure the code adheres to the repository standards
