### PR TITLE
Add TapBark config option to define output elements order

### DIFF
--- a/packages/tap-bark/src/tap-bark.tsx
+++ b/packages/tap-bark/src/tap-bark.tsx
@@ -27,6 +27,7 @@ export interface TapBarkOutputState {
 
 export interface TapBarkOutputProps {
     showProgress: boolean;
+    resultsOrder: string[]
 }
 
 class TapBarkOutputComponent extends Component {
@@ -81,13 +82,22 @@ class TapBarkOutputComponent extends Component {
         const total = this.state.totalTests;
 
         if (this.state.results) {
-            return <Indent>
-                        {this.state.warnings.join("\n")}
-                        <Color green>Pass: {results.pass} / {total}{"\n"}</Color>
-                        <Color red>Fail: {results.fail} / {total}{"\n"}</Color>
-                        <Color yellow>Ignore: {results.ignore} / {total}{"\n"}{"\n"}</Color>
-                        {results.failures.map(this.getFailureMessage.bind(this)).join("\n")}
-                    </Indent>;
+            const resultElement =
+                <Indent>
+                    <Color green>Pass: {results.pass} / {total}</Color>{"\n"}
+                    <Color red>Fail: {results.fail} / {total}</Color>{"\n"}
+                    <Color yellow>Ignore: {results.ignore} / {total}{"\n"}{"\n"}</Color>
+                </Indent>
+            
+            const elements = {
+                warnings: <Indent>{this.state.warnings.join("\n")}</Indent>,
+                results: resultElement,
+                failures: <Indent>{results.failures.map(this.getFailureMessage.bind(this)).join("\n") + "\n"}</Indent>
+            }
+
+            const output = this.props.resultsOrder.map(item => elements[item])
+
+            return <div>{output}</div>;
         }
 
         if (this.props.showProgress === false) {
@@ -178,8 +188,8 @@ export class TapBark {
     
     public static readonly tapParser = TAP_PARSER;
 
-    public static create(showProgress: boolean = true) {
-        const tapBarkOutput = <TapBarkOutput showProgress={showProgress} />;
+    public static create(showProgress: boolean = true, resultsOrder: string[] = ["warnings", "results", "failures"]) {
+        const tapBarkOutput = <TapBarkOutput showProgress={showProgress} resultsOrder={resultsOrder} />;
         render(tapBarkOutput);
         //TODO: remove when proper ink types
         return tapBarkOutput.instance as any as InkElement & TapBarkOutputComponent;


### PR DESCRIPTION
## Description

Adds a `resultsOrder` parameter to method `TapBark.create()` to facilitate custom ordering of the results printed to the console.

Will close #540 when complete.

## Incomplete

I'm unfamiliar with React, Ink and using .tsx files so I have had some formatting issues. I can't see how, but when using this in my own projects the failures format wrong. I'm probably missing something obvious, but can't immediately see what it is.
![image](https://user-images.githubusercontent.com/14295333/62892741-ed66ba80-bd40-11e9-989b-7584f9d02187.png)

I also had problems getting the project fully working on my Windows 10 machine - I assume you are using Linux or Mac OS. I did spend a while trying to troubleshoot but in the end it didn't seem fully worth. I had to re-execute `npm run bootstrap` every time I wanted to do anything, and I wasn't able to get `npm test` working at all.
Anyway, the result is that I haven't validated that all the tests still pass.

Would appreciate some assistance getting this PR fully merge-ready as I don't have lots of spare time to troubleshoot. No offence taken if you reject it, or want to change most of it.