### PR TITLE
Move results below failure details in TapBark output

### DIFF
--- a/packages/tap-bark/src/tap-bark.tsx
+++ b/packages/tap-bark/src/tap-bark.tsx
@@ -83,10 +83,10 @@ class TapBarkOutputComponent extends Component {
         if (this.state.results) {
             return <Indent>
                         {this.state.warnings.join("\n")}
+                        {results.failures.map(this.getFailureMessage.bind(this)).join("\n")}
                         <Color green>Pass: {results.pass} / {total}{"\n"}</Color>
                         <Color red>Fail: {results.fail} / {total}{"\n"}</Color>
                         <Color yellow>Ignore: {results.ignore} / {total}{"\n"}{"\n"}</Color>
-                        {results.failures.map(this.getFailureMessage.bind(this)).join("\n")}
                     </Indent>;
         }
 


### PR DESCRIPTION
Re-organises TapBark output so that results show at the bottom of the output, immediately view-able regardless of how large the failure output is.

Closes #540 
See discussion in #540 and #550 