### PR TITLE
hideProgress uses now the CI env variable

### DIFF
--- a/packages/alsatian/cli/cli-test-runner.ts
+++ b/packages/alsatian/cli/cli-test-runner.ts
@@ -58,7 +58,8 @@ export class CliTestRunner {
 			this._testRunner.outputStream.pipe(process.stdout);
 		} else {
 			// otherwise create the tap bark reporter
-			const bark = TapBark.create(userArguments.hideProgress === false);
+			const hideProgress = (process.env.CI || userArguments.hideProgress);
+			const bark = TapBark.create(hideProgress === false);
 
 			// pipe the reporter into stdout
 			this._testRunner.outputStream

--- a/packages/alsatian/cli/cli-test-runner.ts
+++ b/packages/alsatian/cli/cli-test-runner.ts
@@ -26,26 +26,7 @@ export class CliTestRunner {
 
 		// if help has been requested then output info about using the CLI and exit
 		if (userArguments.helpRequested) {
-			process.stdout.write(
-				"\n\n" +
-					"alsatian version " +
-					packageJson.version +
-					"\n" +
-					"=========================\n" +
-					"CLI options\n" +
-					"=========================\n" +
-					"HELP:    --help / -h                      " +
-					"(outputs CLI information)\n" +
-					"VERSION: --version / -v                   " +
-					"(outputs the version of the CLI)\n" +
-					"TAP:     --tap / -T                       " +
-					"(runs alsatian with TAP output)\n" +
-					"TIMEOUT: --timeout [number] / -t [number] " +
-					"(sets the timeout period for tests in milliseconds - default 500)\n" +
-					"HIDE PROGRESS: --hide-progress / -H " +
-					"(hides progress from console)\n" +
-					"\n"
-			);
+			this._printHelp(packageJson.version);
 			return;
 		}
 
@@ -58,13 +39,7 @@ export class CliTestRunner {
 			this._testRunner.outputStream.pipe(process.stdout);
 		} else {
 			// otherwise create the tap bark reporter
-			const hideProgress = (process.env.CI || userArguments.hideProgress);
-			const bark = TapBark.create(hideProgress === false);
-
-			// pipe the reporter into stdout
-			this._testRunner.outputStream
-				.pipe(bark.getPipeable())
-				.pipe(process.stdout);
+			this._createTapBarkReporter(userArguments.hideProgress);
 		}
 
 		try {
@@ -74,8 +49,41 @@ export class CliTestRunner {
 		}
 	}
 
+	private _createTapBarkReporter(hideProgressArgument: boolean) {
+		const hideProgress = (process.env.CI || hideProgressArgument);
+		const bark = TapBark.create(hideProgress === false);
+
+		// pipe the reporter into stdout
+		this._testRunner.outputStream
+			.pipe(bark.getPipeable())
+			.pipe(process.stdout);
+	}
+
 	private _handleTestSetRunError(error: Error) {
 		process.stderr.write(error.message + "\n");
 		process.exit(1);
+	}
+
+	private _printHelp(version: string) {
+		process.stdout.write(
+			"\n\n" +
+				"alsatian version " +
+				version +
+				"\n" +
+				"=========================\n" +
+				"CLI options\n" +
+				"=========================\n" +
+				"HELP:    --help / -h                      " +
+				"(outputs CLI information)\n" +
+				"VERSION: --version / -v                   " +
+				"(outputs the version of the CLI)\n" +
+				"TAP:     --tap / -T                       " +
+				"(runs alsatian with TAP output)\n" +
+				"TIMEOUT: --timeout [number] / -t [number] " +
+				"(sets the timeout period for tests in milliseconds - default 500)\n" +
+				"HIDE PROGRESS: --hide-progress / -H " +
+				"(hides progress from console)\n" +
+				"\n"
+		);
 	}
 }


### PR DESCRIPTION
<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

# Description

The test runner now hides the progress if the `CI` env variable is true.

For example running `CI=true alsatian test.ts` will hide the progress.
This is useful in Continous Integration services

# Checklist

- [x] I am an awesome developer and proud of my code
- [ ] I added / updated / removed relevant unit or integration tests to prove my change works (I don't think it is worth to add a test, but if you want, I don't have any problem to add one)
- [X] I ran all tests using ```npm test``` to make sure everything else still works
- [ ] I ran ```npm run review``` to ensure the code adheres to the repository standards (`npm ERR! missing script: review`)

<!-- Thanks again, and if you'd like to add any further information you can do so below -->

# Additional Information
