### PR TITLE
enable Any to be called without a constructor for use with interfaces

### DIFF
--- a/packages/alsatian/core/_interfaces/constructor.ts
+++ b/packages/alsatian/core/_interfaces/constructor.ts
@@ -1,2 +1,2 @@
 // tslint:disable-next-line:interface-over-type-literal
-export type Constructor = new (...args: Array<any>) => object;
+export type Constructor<T = object> = new (...args: Array<any>) => T;

--- a/packages/alsatian/core/alsatian-core.ts
+++ b/packages/alsatian/core/alsatian-core.ts
@@ -40,6 +40,7 @@ import {
 	Any,
 	createFunctionSpy,
 	FunctionSpy,
+	ISpiedFunction,
 	RestorableFunctionSpy,
 	SpyOn,
 	SpyOnProperty

--- a/packages/alsatian/core/spying/any-argument.ts
+++ b/packages/alsatian/core/spying/any-argument.ts
@@ -1,9 +1,10 @@
 import { TypeMatcher } from "../spying";
 import { InterfaceMatcher } from "./interface-matcher";
 import { MatcherOrType } from "./matcher-or-type";
+import { Constructor } from "../_interfaces";
 
 export function Any<ExpectedType extends object>(): InterfaceMatcher<ExpectedType>;
-export function Any<ExpectedType extends object>(type: new (...args: Array<any>) => ExpectedType): MatcherOrType<ExpectedType>;
+export function Any<ExpectedType extends object>(type: Constructor<ExpectedType>): MatcherOrType<ExpectedType>;
 export function Any<ExpectedType extends object>(
 	type?: new (...args: Array<any>) => ExpectedType
 ): MatcherOrType<ExpectedType> | InterfaceMatcher<ExpectedType> {

--- a/packages/alsatian/core/spying/any-argument.ts
+++ b/packages/alsatian/core/spying/any-argument.ts
@@ -1,7 +1,15 @@
 import { TypeMatcher } from "../spying";
+import { InterfaceMatcher } from "./interface-matcher";
+import { MatcherOrType } from "./matcher-or-type";
 
+export function Any<ExpectedType extends object>(): InterfaceMatcher<ExpectedType>;
+export function Any<ExpectedType extends object>(type: new (...args: Array<any>) => ExpectedType): MatcherOrType<ExpectedType>;
 export function Any<ExpectedType extends object>(
-	type: new (...args: Array<any>) => ExpectedType
-): TypeMatcher<ExpectedType> & ExpectedType {
-	return new TypeMatcher<ExpectedType>(type) as TypeMatcher<ExpectedType> & ExpectedType;
+	type?: new (...args: Array<any>) => ExpectedType
+): MatcherOrType<ExpectedType> | InterfaceMatcher<ExpectedType> {
+	if (type) {
+		return new TypeMatcher<ExpectedType>(type) as MatcherOrType<ExpectedType>;
+	}
+
+	return new InterfaceMatcher<ExpectedType>();
 }

--- a/packages/alsatian/core/spying/index.ts
+++ b/packages/alsatian/core/spying/index.ts
@@ -1,6 +1,7 @@
 export { Any } from "./any-argument";
 export { createFunctionSpy } from "./create-function-spy";
 export { FunctionSpy } from "./function-spy";
+export { ISpiedFunction } from "./spied-function.i";
 export { PropertySpy } from "./property-spy";
 export { RestorableFunctionSpy } from "./restorable-function-spy";
 export { SpyCall } from "./spy-call";

--- a/packages/alsatian/core/spying/interface-matcher.ts
+++ b/packages/alsatian/core/spying/interface-matcher.ts
@@ -1,14 +1,12 @@
 import { MatcherOrType } from "./matcher-or-type";
 import { TypeMatcher } from "./type-matcher";
+import { SpyMatcher } from "./spy-matcher";
 
-export class InterfaceMatcher<ExpectedType extends object> {
-	public thatMatches<Key extends keyof ExpectedType>(key: Key, value: ExpectedType[Key]): MatcherOrType<ExpectedType>;
-	public thatMatches(properties: Partial<ExpectedType>): MatcherOrType<ExpectedType>;
-	public thatMatches(delegate: (argument: ExpectedType) => boolean): MatcherOrType<ExpectedType>;
+export class InterfaceMatcher<ExpectedType extends object> implements SpyMatcher<ExpectedType> {
 	public thatMatches<Key extends keyof ExpectedType>(
 		first: Key | Partial<ExpectedType> | ((argument: ExpectedType) => boolean),
 		second?: ExpectedType[Key]
 	): MatcherOrType<ExpectedType> {
-		return new TypeMatcher<ExpectedType>(Object as any).thatMatches(first as Key, second) as MatcherOrType<ExpectedType>;
+		return new TypeMatcher<ExpectedType>(Object as any).thatMatches(first as Key, second);
 	}
 }

--- a/packages/alsatian/core/spying/interface-matcher.ts
+++ b/packages/alsatian/core/spying/interface-matcher.ts
@@ -1,0 +1,14 @@
+import { MatcherOrType } from "./matcher-or-type";
+import { TypeMatcher } from "./type-matcher";
+
+export class InterfaceMatcher<ExpectedType extends object> {
+	public thatMatches<Key extends keyof ExpectedType>(key: Key, value: ExpectedType[Key]): MatcherOrType<ExpectedType>;
+	public thatMatches(properties: Partial<ExpectedType>): MatcherOrType<ExpectedType>;
+	public thatMatches(delegate: (argument: ExpectedType) => boolean): MatcherOrType<ExpectedType>;
+	public thatMatches<Key extends keyof ExpectedType>(
+		first: Key | Partial<ExpectedType> | ((argument: ExpectedType) => boolean),
+		second?: ExpectedType[Key]
+	): MatcherOrType<ExpectedType> {
+		return new TypeMatcher<ExpectedType>(Object as any).thatMatches(first as Key, second) as MatcherOrType<ExpectedType>;
+	}
+}

--- a/packages/alsatian/core/spying/interface-matcher.ts
+++ b/packages/alsatian/core/spying/interface-matcher.ts
@@ -1,11 +1,9 @@
 import { MatcherOrType } from "./matcher-or-type";
 import { TypeMatcher } from "./type-matcher";
-export type MatcherArgument<ExpectedType, Key extends keyof ExpectedType> = Key | Partial<ExpectedType> | ((argument: ExpectedType) => boolean);
+import { MatcherArgument } from "./matcher-argument";
+import { ISpyMatcher } from "./spy-matcher.i";
 
-export class InterfaceMatcher<ExpectedType extends object> {
-	public thatMatches<Key extends keyof ExpectedType>(key: Key, value: ExpectedType[Key]): MatcherOrType<ExpectedType>;
-	public thatMatches(properties: Partial<ExpectedType>): MatcherOrType<ExpectedType>;
-	public thatMatches(delegate: (argument: ExpectedType) => boolean): MatcherOrType<ExpectedType>;
+export class InterfaceMatcher<ExpectedType extends object> implements ISpyMatcher<ExpectedType> {
 	public thatMatches<Key extends keyof ExpectedType>(
 		first: MatcherArgument<ExpectedType, Key>,
 		second?: ExpectedType[Key]

--- a/packages/alsatian/core/spying/interface-matcher.ts
+++ b/packages/alsatian/core/spying/interface-matcher.ts
@@ -1,12 +1,13 @@
 import { MatcherOrType } from "./matcher-or-type";
 import { TypeMatcher } from "./type-matcher";
+export type MatcherArgument<ExpectedType, Key extends keyof ExpectedType> = Key | Partial<ExpectedType> | ((argument: ExpectedType) => boolean);
 
 export class InterfaceMatcher<ExpectedType extends object> {
 	public thatMatches<Key extends keyof ExpectedType>(key: Key, value: ExpectedType[Key]): MatcherOrType<ExpectedType>;
 	public thatMatches(properties: Partial<ExpectedType>): MatcherOrType<ExpectedType>;
 	public thatMatches(delegate: (argument: ExpectedType) => boolean): MatcherOrType<ExpectedType>;
 	public thatMatches<Key extends keyof ExpectedType>(
-		first: Key | Partial<ExpectedType> | ((argument: ExpectedType) => boolean),
+		first: MatcherArgument<ExpectedType, Key>,
 		second?: ExpectedType[Key]
 	): MatcherOrType<ExpectedType> {
 		return new TypeMatcher<ExpectedType>(Object as any).thatMatches(first as Key, second);

--- a/packages/alsatian/core/spying/interface-matcher.ts
+++ b/packages/alsatian/core/spying/interface-matcher.ts
@@ -1,8 +1,10 @@
 import { MatcherOrType } from "./matcher-or-type";
 import { TypeMatcher } from "./type-matcher";
-import { SpyMatcher } from "./spy-matcher";
 
-export class InterfaceMatcher<ExpectedType extends object> implements SpyMatcher<ExpectedType> {
+export class InterfaceMatcher<ExpectedType extends object> {
+	public thatMatches<Key extends keyof ExpectedType>(key: Key, value: ExpectedType[Key]): MatcherOrType<ExpectedType>;
+	public thatMatches(properties: Partial<ExpectedType>): MatcherOrType<ExpectedType>;
+	public thatMatches(delegate: (argument: ExpectedType) => boolean): MatcherOrType<ExpectedType>;
 	public thatMatches<Key extends keyof ExpectedType>(
 		first: Key | Partial<ExpectedType> | ((argument: ExpectedType) => boolean),
 		second?: ExpectedType[Key]

--- a/packages/alsatian/core/spying/matcher-argument.ts
+++ b/packages/alsatian/core/spying/matcher-argument.ts
@@ -1,0 +1,3 @@
+export type MatcherArgument<ExpectedType, Key extends keyof ExpectedType> = Key 
+                                                                          | Partial<ExpectedType>
+                                                                          | ((argument: ExpectedType) => boolean);

--- a/packages/alsatian/core/spying/matcher-argument.ts
+++ b/packages/alsatian/core/spying/matcher-argument.ts
@@ -1,3 +1,3 @@
-export type MatcherArgument<ExpectedType, Key extends keyof ExpectedType> = Key 
-                                                                          | Partial<ExpectedType>
-                                                                          | ((argument: ExpectedType) => boolean);
+export type MatcherArgument<ExpectedType, Key extends keyof ExpectedType> = Key
+																			| Partial<ExpectedType>
+																			| ((argument: ExpectedType) => boolean);

--- a/packages/alsatian/core/spying/matcher-or-type.ts
+++ b/packages/alsatian/core/spying/matcher-or-type.ts
@@ -1,0 +1,3 @@
+import { TypeMatcher } from "./type-matcher";
+
+export type MatcherOrType<Type extends object> = TypeMatcher<Type> & Type;

--- a/packages/alsatian/core/spying/matcher-or-type.ts
+++ b/packages/alsatian/core/spying/matcher-or-type.ts
@@ -1,3 +1,3 @@
 import { TypeMatcher } from "./type-matcher";
 
-export type MatcherOrType<Type extends object> = TypeMatcher<Type> | Type;
+export type MatcherOrType<Type extends object> = TypeMatcher<Type> & Type;

--- a/packages/alsatian/core/spying/matcher-or-type.ts
+++ b/packages/alsatian/core/spying/matcher-or-type.ts
@@ -1,3 +1,3 @@
 import { TypeMatcher } from "./type-matcher";
 
-export type MatcherOrType<Type extends object> = TypeMatcher<Type> & Type;
+export type MatcherOrType<Type extends object> = TypeMatcher<Type> | Type;

--- a/packages/alsatian/core/spying/spy-matcher.i.ts
+++ b/packages/alsatian/core/spying/spy-matcher.i.ts
@@ -1,0 +1,9 @@
+import { MatcherOrType } from "./matcher-or-type";
+
+export interface ISpyMatcher<ExpectedType extends object> {
+	/* tslint:disable:unified-signatures */
+	thatMatches<Key extends keyof ExpectedType>(key: Key, value: ExpectedType[Key]): MatcherOrType<ExpectedType>;
+	thatMatches(properties: Partial<ExpectedType>): MatcherOrType<ExpectedType>;
+	thatMatches(delegate: (argument: ExpectedType) => boolean): MatcherOrType<ExpectedType>;
+	/* tslint:enable:unified-signatures */
+}

--- a/packages/alsatian/core/spying/spy-matcher.ts
+++ b/packages/alsatian/core/spying/spy-matcher.ts
@@ -1,0 +1,9 @@
+import { MatcherOrType } from "./matcher-or-type";
+
+export interface SpyMatcher<ExpectedType extends object> {    
+	/* tslint:disable:unified-signatures */
+	thatMatches<Key extends keyof ExpectedType>(key: Key, value: ExpectedType[Key]): MatcherOrType<ExpectedType>;
+	thatMatches(properties: Partial<ExpectedType>): MatcherOrType<ExpectedType>;
+	thatMatches(delegate: (argument: ExpectedType) => boolean): MatcherOrType<ExpectedType>;
+	/* tslint:enable:unified-signatures */
+}

--- a/packages/alsatian/core/spying/spy-matcher.ts
+++ b/packages/alsatian/core/spying/spy-matcher.ts
@@ -1,9 +1,0 @@
-import { MatcherOrType } from "./matcher-or-type";
-
-export interface SpyMatcher<ExpectedType extends object> {    
-	/* tslint:disable:unified-signatures */
-	thatMatches<Key extends keyof ExpectedType>(key: Key, value: ExpectedType[Key]): MatcherOrType<ExpectedType>;
-	thatMatches(properties: Partial<ExpectedType>): MatcherOrType<ExpectedType>;
-	thatMatches(delegate: (argument: ExpectedType) => boolean): MatcherOrType<ExpectedType>;
-	/* tslint:enable:unified-signatures */
-}

--- a/packages/alsatian/core/spying/type-matcher.ts
+++ b/packages/alsatian/core/spying/type-matcher.ts
@@ -47,12 +47,12 @@ export class TypeMatcher<ExpectedType extends object> {
 	}
 
 	/* tslint:disable:unified-signatures */
-	public thatMatches(key: string, value: any): this;
-	public thatMatches(properties: object): this;
+	public thatMatches<Key extends keyof ExpectedType>(key: Key, value: ExpectedType[Key]): this;
+	public thatMatches(properties: Partial<ExpectedType>): this;
 	public thatMatches(delegate: (argument: ExpectedType) => boolean): this;
-	public thatMatches(
-		first: string | object | ((argument: ExpectedType) => boolean),
-		second?: any
+	public thatMatches<Key extends keyof ExpectedType>(
+		first: Key | Partial<ExpectedType> | ((argument: ExpectedType) => boolean),
+		second?: ExpectedType[Key]
 	): this {
 		if (null === first || undefined === first) {
 			throw new TypeError(

--- a/packages/alsatian/core/spying/type-matcher.ts
+++ b/packages/alsatian/core/spying/type-matcher.ts
@@ -2,8 +2,9 @@ import { stringify } from "../stringification";
 import { ITester, INameable } from "../_interfaces";
 import { SpyMatcher } from "./spy-matcher";
 import { MatcherOrType } from "./matcher-or-type";
+import { InterfaceMatcher } from "./interface-matcher";
 
-export class TypeMatcher<ExpectedType extends object> implements SpyMatcher<ExpectedType> {
+export class TypeMatcher<ExpectedType extends object> extends InterfaceMatcher<ExpectedType> {
 	private _testers: Array<ITester> = [];
 	private _type: new (...args: Array<any>) => ExpectedType;
 	public get type() {
@@ -11,6 +12,8 @@ export class TypeMatcher<ExpectedType extends object> implements SpyMatcher<Expe
 	}
 
 	public constructor(type: new (...args: Array<any>) => ExpectedType) {
+		super();
+
 		if (type === null || type === undefined) {
 			throw new TypeError("type must not be null or undefined");
 		}
@@ -89,7 +92,7 @@ export class TypeMatcher<ExpectedType extends object> implements SpyMatcher<Expe
 			}
 		});
 
-		return this;
+		return this._thisAsMatcherOrType();
 	}
 
 	private _matchesDelegate(
@@ -100,7 +103,7 @@ export class TypeMatcher<ExpectedType extends object> implements SpyMatcher<Expe
 			test: (v: any) => delegate(v)
 		});
 
-		return this;
+		return this._thisAsMatcherOrType();
 	}
 
 	private _matchesObjectLiteral(properties: object): MatcherOrType<ExpectedType> {
@@ -118,6 +121,10 @@ export class TypeMatcher<ExpectedType extends object> implements SpyMatcher<Expe
 			}
 		});
 
-		return this;
+		return this._thisAsMatcherOrType();
+	}
+
+	private _thisAsMatcherOrType() {
+		return this as unknown as MatcherOrType<ExpectedType>;
 	}
 }

--- a/packages/alsatian/core/spying/type-matcher.ts
+++ b/packages/alsatian/core/spying/type-matcher.ts
@@ -1,43 +1,35 @@
 import { stringify } from "../stringification";
 import { ITester, INameable } from "../_interfaces";
-import { SpyMatcher } from "./spy-matcher";
+import { ISpyMatcher } from "./spy-matcher.i";
 import { MatcherOrType } from "./matcher-or-type";
-import { InterfaceMatcher, MatcherArgument } from "./interface-matcher";
+import { MatcherArgument } from "./matcher-argument";
 
-export class TypeMatcher<ExpectedType extends object> extends InterfaceMatcher<ExpectedType> {
-	private _testers: Array<ITester> = [];
-	private _type: new (...args: Array<any>) => ExpectedType;
-	public get type() {
-		return this._type;
-	}
+export class TypeMatcher<ExpectedType extends object> implements ISpyMatcher<ExpectedType> {
+	private readonly _testers: Array<ITester> = [];
 
-	public constructor(type: new (...args: Array<any>) => ExpectedType) {
-		super();
-
+	public constructor(public readonly type: new (...args: Array<any>) => ExpectedType) {
 		if (type === null || type === undefined) {
 			throw new TypeError("type must not be null or undefined");
 		}
-
-		this._type = type;
 
 		this._testers.push({
 			stringify: () => `Any ${(this.type as INameable).name}`,
 			test: (value: any) => {
 				if ((type as any) === String) {
 					return (
-						typeof value === "string" || value instanceof this._type
+						typeof value === "string" || value instanceof this.type
 					);
 				} else if ((type as any) === Number) {
 					return (
-						typeof value === "number" || value instanceof this._type
+						typeof value === "number" || value instanceof this.type
 					);
 				} else if ((type as any) === Boolean) {
 					return (
 						typeof value === "boolean" ||
-						value instanceof this._type
+						value instanceof this.type
 					);
 				} else {
-					return value instanceof this._type;
+					return value instanceof this.type;
 				}
 			}
 		});

--- a/packages/alsatian/core/spying/type-matcher.ts
+++ b/packages/alsatian/core/spying/type-matcher.ts
@@ -2,7 +2,7 @@ import { stringify } from "../stringification";
 import { ITester, INameable } from "../_interfaces";
 import { SpyMatcher } from "./spy-matcher";
 import { MatcherOrType } from "./matcher-or-type";
-import { InterfaceMatcher } from "./interface-matcher";
+import { InterfaceMatcher, MatcherArgument } from "./interface-matcher";
 
 export class TypeMatcher<ExpectedType extends object> extends InterfaceMatcher<ExpectedType> {
 	private _testers: Array<ITester> = [];
@@ -52,7 +52,7 @@ export class TypeMatcher<ExpectedType extends object> extends InterfaceMatcher<E
 	}
 
 	public thatMatches<Key extends keyof ExpectedType>(
-		first: Key | Partial<ExpectedType> | ((argument: ExpectedType) => boolean),
+		first: MatcherArgument<ExpectedType, Key>,
 		second?: ExpectedType[Key]
 	): MatcherOrType<ExpectedType> {
 		if (null === first || undefined === first) {

--- a/packages/alsatian/test/unit-tests/expect-tests/to-equal.spec.ts
+++ b/packages/alsatian/test/unit-tests/expect-tests/to-equal.spec.ts
@@ -202,11 +202,11 @@ export class ToEqualTests {
 
 	@TestCase(Any(Number), 42)
 	@TestCase(Any(String), "something")
-	@TestCase(Any(Object).thatMatches("property", 42), {
+	@TestCase(Any<{ property: number }>().thatMatches("property", 42), {
 		property: 42,
 		anotherProperty: "something"
 	})
-	@TestCase(Any(Object).thatMatches({ anotherProperty: "something" }), {
+	@TestCase(Any<{ anotherProperty: string }>().thatMatches({ anotherProperty: "something" }), {
 		property: 42,
 		anotherProperty: "something"
 	})
@@ -218,11 +218,11 @@ export class ToEqualTests {
 
 	@TestCase(Any(Number), "something")
 	@TestCase(Any(String), 42)
-	@TestCase(Any(Object).thatMatches("property", 42), {
+	@TestCase(Any<{ property: number }>().thatMatches("property", 42), {
 		property: "something",
 		anotherProperty: 42
 	})
-	@TestCase(Any(Object).thatMatches({ anotherProperty: "something" }), {
+	@TestCase(Any<{ anotherProperty: string }>().thatMatches({ anotherProperty: "something" }), {
 		property: "something",
 		anotherProperty: 42
 	})
@@ -234,11 +234,11 @@ export class ToEqualTests {
 
 	@TestCase(Any(Number), "something")
 	@TestCase(Any(String), 42, "Expected 42 to be equal to Any String.")
-	@TestCase(Any(Object).thatMatches("property", 42), {
+	@TestCase(Any<{ property: number }>().thatMatches("property", 42), {
 		property: "something",
 		anotherProperty: 42
 	})
-	@TestCase(Any(Object).thatMatches({ anotherProperty: "something" }), {
+	@TestCase(Any<{ anotherProperty: string }>().thatMatches({ anotherProperty: "something" }), {
 		property: "something",
 		anotherProperty: 42
 	})

--- a/packages/alsatian/test/unit-tests/spying/any-arguments.spec.ts
+++ b/packages/alsatian/test/unit-tests/spying/any-arguments.spec.ts
@@ -1,6 +1,7 @@
-import { Expect, TestCase } from "../../../core/alsatian-core";
+import { Expect, TestCase, Test } from "../../../core/alsatian-core";
 import { Any } from "../../../core/spying/any-argument";
 import { TypeMatcher } from "../../../core/spying/type-matcher";
+import { InterfaceMatcher } from "../../../core/spying/interface-matcher";
 
 export class AnyArgumentsTests {
 	@TestCase(null)
@@ -20,5 +21,12 @@ export class AnyArgumentsTests {
 	@TestCase(Error)
 	public anyReturnsTypeMatcher(type: new (...args: Array<any>) => object) {
 		Expect(Any(type) instanceof TypeMatcher).toBe(true);
+	}
+
+	@Test("Any called with no arguments returns an InterfaceMatcher")
+	public anyReturnsInterfaceMatcherIfNoArguments() {		
+		interface SampleInterface {}
+
+		Expect(Any<SampleInterface>()).toEqual(Any(InterfaceMatcher));
 	}
 }

--- a/packages/alsatian/test/unit-tests/spying/any-arguments.spec.ts
+++ b/packages/alsatian/test/unit-tests/spying/any-arguments.spec.ts
@@ -24,9 +24,11 @@ export class AnyArgumentsTests {
 	}
 
 	@Test("Any called with no arguments returns an InterfaceMatcher")
-	public anyReturnsInterfaceMatcherIfNoArguments() {		
-		interface SampleInterface {}
+	public anyReturnsInterfaceMatcherIfNoArguments() {
+		interface ISampleInterface {
+			example: string;
+		}
 
-		Expect(Any<SampleInterface>()).toEqual(Any(InterfaceMatcher));
+		Expect(Any<ISampleInterface>()).toEqual(Any(InterfaceMatcher));
 	}
 }

--- a/packages/alsatian/test/unit-tests/spying/any-arguments.spec.ts
+++ b/packages/alsatian/test/unit-tests/spying/any-arguments.spec.ts
@@ -4,15 +4,6 @@ import { TypeMatcher } from "../../../core/spying/type-matcher";
 import { InterfaceMatcher } from "../../../core/spying/interface-matcher";
 
 export class AnyArgumentsTests {
-	@TestCase(null)
-	@TestCase(undefined)
-	public nullOrUndefinedTypesThrowError(type: any) {
-		Expect(() => Any(type)).toThrowError(
-			TypeError,
-			"type must not be null or undefined"
-		);
-	}
-
 	@TestCase(Number)
 	@TestCase(String)
 	@TestCase(Boolean)

--- a/packages/alsatian/test/unit-tests/spying/interface-matcher.spec.ts
+++ b/packages/alsatian/test/unit-tests/spying/interface-matcher.spec.ts
@@ -4,21 +4,21 @@ import { TypeMatcher, Any } from "../../../core/spying";
 
 export class InterfaceMatcherSpecs {
 
-    @Test("calling thatMatches returns a TypeMatcher")
-    public typeMatcherReturned() {
-        const interfaceMatcher = new InterfaceMatcher();
+	@Test("calling thatMatches returns a TypeMatcher")
+	public typeMatcherReturned() {
+		const interfaceMatcher = new InterfaceMatcher();
 
-        Expect(interfaceMatcher.thatMatches({})).toEqual(Any(TypeMatcher));
-    }
+		Expect(interfaceMatcher.thatMatches({})).toEqual(Any(TypeMatcher));
+	}
 
-    @Test("TypeMatcher test function works as expected")
-    public testFunctionHookedUp() {
-        const interfaceMatcher = new InterfaceMatcher<{ expected: string }>();
+	@Test("TypeMatcher test function works as expected")
+	public testFunctionHookedUp() {
+		const interfaceMatcher = new InterfaceMatcher<{ expected: string }>();
 
-        const typeMatcher = interfaceMatcher.thatMatches("expected", "value");
+		const typeMatcher = interfaceMatcher.thatMatches("expected", "value");
 
-        Expect(typeMatcher.test({ expected: "value" })).toBe(true);
-        Expect(typeMatcher.test({ unexpected: "value" })).toBe(false);
-        Expect(typeMatcher.test({ expected: "wrong value" })).toBe(false);
-    }
+		Expect(typeMatcher.test({ expected: "value" })).toBe(true);
+		Expect(typeMatcher.test({ unexpected: "value" })).toBe(false);
+		Expect(typeMatcher.test({ expected: "wrong value" })).toBe(false);
+	}
 }

--- a/packages/alsatian/test/unit-tests/spying/interface-matcher.spec.ts
+++ b/packages/alsatian/test/unit-tests/spying/interface-matcher.spec.ts
@@ -1,0 +1,24 @@
+import { Expect, Test } from "../../../core/alsatian-core";
+import { InterfaceMatcher } from "../../../core/spying/interface-matcher";
+import { TypeMatcher, Any } from "../../../core/spying";
+
+export class InterfaceMatcherSpecs {
+
+    @Test("calling thatMatches returns a TypeMatcher")
+    public typeMatcherReturned() {
+        const interfaceMatcher = new InterfaceMatcher();
+
+        Expect(interfaceMatcher.thatMatches({})).toEqual(Any(TypeMatcher));
+    }
+
+    @Test("TypeMatcher test function works as expected")
+    public testFunctionHookedUp() {
+        const interfaceMatcher = new InterfaceMatcher<{ expected: string }>();
+
+        const typeMatcher = interfaceMatcher.thatMatches("expected", "value");
+
+        Expect(typeMatcher.test({ expected: "value" })).toBe(true);
+        Expect(typeMatcher.test({ unexpected: "value" })).toBe(false);
+        Expect(typeMatcher.test({ expected: "wrong value" })).toBe(false);
+    }
+}

--- a/packages/alsatian/test/unit-tests/spying/type-matcher/test.spec.ts
+++ b/packages/alsatian/test/unit-tests/spying/type-matcher/test.spec.ts
@@ -231,7 +231,7 @@ export class TypeMatcherTestFunctionTests {
 	@Test()
 	public thatMatchesWithValidArgumentsDoesNotThrow() {
 		const sut = new TypeMatcher(Error);
-		Expect(() => sut.thatMatches("a", null)).not.toThrow();
+		Expect(() => sut.thatMatches("name", null)).not.toThrow();
 		Expect(() => sut.thatMatches({})).not.toThrow();
 		Expect(() => sut.thatMatches((v: Error) => true)).not.toThrow();
 	}
@@ -281,7 +281,7 @@ export class TypeMatcherTestFunctionTests {
 	@TestCase([2], "length", 1, true)
 	public thatMatchesWithKeyAndValueReturnsExpected<ItemType extends object>(
 		item: ItemType,
-		key: string,
+		key: keyof ItemType,
 		value: any,
 		output: boolean
 	) {

--- a/packages/alsatian/tslint.json
+++ b/packages/alsatian/tslint.json
@@ -9,7 +9,8 @@
     "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"],
     "ordered-imports": false,
     "object-literal-sort-keys": false,
-    "indent": [true, "tabs", 4]
+    "indent": [true, "tabs", 4],
+    "unified-signatures": false
   },
   "jsRules": {
   },

--- a/packages/tap-bark/src/tap-bark.tsx
+++ b/packages/tap-bark/src/tap-bark.tsx
@@ -15,7 +15,7 @@ const TAP_PARSER: { on: (eventName: string, callback: Function) => void } = pars
 export interface TapBarkOutputState {
     logs: Array<string>;
     warnings: Array<string>;
-    fixtureName: string;
+    fixtureName?: string;
     results?: {
         pass: number;
         fail: number;

--- a/packages/tap-bark/src/tap-bark.tsx
+++ b/packages/tap-bark/src/tap-bark.tsx
@@ -15,6 +15,7 @@ const TAP_PARSER: { on: (eventName: string, callback: Function) => void } = pars
 export interface TapBarkOutputState {
     logs: Array<string>;
     warnings: Array<string>;
+    fixtureName: string;
     results?: {
         pass: number;
         fail: number;

--- a/packages/tap-bark/src/tap-bark.tsx
+++ b/packages/tap-bark/src/tap-bark.tsx
@@ -24,6 +24,7 @@ export interface TapBarkOutputState {
     };
     totalTests?: number;
     currentTest?: number;
+    testName?: string;
 }
 
 export interface TapBarkOutputProps {

--- a/packages/tap-bark/test/unit-tests/src/tap-bark.test.ts
+++ b/packages/tap-bark/test/unit-tests/src/tap-bark.test.ts
@@ -8,7 +8,7 @@ import {
 	Teardown,
 	TestFixture
 } from "alsatian";
-import { TapBark, TapBarkOutput } from "../../../src/tap-bark";
+import { TapBark, TapBarkOutput, TapBarkOutputState } from "../../../src/tap-bark";
 
 async function wait(timeInMs: number) {
 	return new Promise(resolve => {
@@ -137,12 +137,12 @@ export default class TapBarkTests {
 		assertEventHandler({ id: 1 });
 
 		Expect(setStateSpy).toHaveBeenCalledWith(
-			Any(Object).thatMatches({
+			Any<TapBarkOutputState>().thatMatches({
 				totalTests: planEnd
 			})
 		);
 
-		Expect(setStateSpy).toHaveBeenCalledWith(
+		Expect<TapBarkOutputState>().toHaveBeenCalledWith(
 			Any(Object).thatMatches({
 				currentTest: 1
 			})
@@ -165,7 +165,7 @@ export default class TapBarkTests {
 		commentEventHandler("# FIXTURE " + fixtureName);
 
 		Expect(setStateSpy).toHaveBeenCalledWith(
-			Any(Object).thatMatches({
+			Any<TapBarkOutputState>().thatMatches({
 				fixtureName
 			})
 		);
@@ -187,7 +187,7 @@ export default class TapBarkTests {
 		commentEventHandler(comment);
 
 		Expect(setStateSpy).not.toHaveBeenCalledWith(
-			Any(Object).thatMatches({
+			Any<TapBarkOutputState>().thatMatches({
 				fixtureName: Any
 			})
 		);

--- a/packages/tap-bark/test/unit-tests/src/tap-bark.test.ts
+++ b/packages/tap-bark/test/unit-tests/src/tap-bark.test.ts
@@ -187,9 +187,7 @@ export default class TapBarkTests {
 		commentEventHandler(comment);
 
 		Expect(setStateSpy).not.toHaveBeenCalledWith(
-			Any<TapBarkOutputState>().thatMatches({
-				fixtureName: Any
-			})
+			Any<TapBarkOutputState>().thatMatches(value => value.fixtureName !== undefined)
 		);
 	}
 

--- a/packages/tap-bark/test/unit-tests/src/tap-bark.test.ts
+++ b/packages/tap-bark/test/unit-tests/src/tap-bark.test.ts
@@ -142,8 +142,8 @@ export default class TapBarkTests {
 			})
 		);
 
-		Expect<TapBarkOutputState>().toHaveBeenCalledWith(
-			Any(Object).thatMatches({
+		Expect(setStateSpy).toHaveBeenCalledWith(
+			Any<TapBarkOutputState>().thatMatches({
 				currentTest: 1
 			})
 		);
@@ -209,7 +209,7 @@ export default class TapBarkTests {
 		assertEventHandler({ name: testName });
 
 		Expect(setStateSpy).toHaveBeenCalledWith(
-			Any(Object).thatMatches({
+			Any<TapBarkOutputState>().thatMatches({
 				testName
 			})
 		);
@@ -237,7 +237,7 @@ export default class TapBarkTests {
 		assertEventHandler({ id: testId });
 
 		Expect(setStateSpy).toHaveBeenCalledWith(
-			Any(Object).thatMatches({
+			Any<TapBarkOutputState>().thatMatches({
 				currentTest: testId
 			})
 		);


### PR DESCRIPTION
<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

# Description

Enable Any to be called without a constructor for use with interfaces, @OwenPattison this should solve #541 for you - are you happy with the solution?

# Checklist

- [x] I am an awesome developer and proud of my code
- [x] I added / updated / removed relevant unit or integration tests to prove my change works
- [x] I ran all tests using ```npm test``` to make sure everything else still works
- [x] I ran ```npm run review``` to ensure the code adheres to the repository standards
