### PR TITLE
fix: Correct typo `depreacated` => `deprecated`

### DIFF
--- a/packages/alsatian/core/maintenance/deprecate.ts
+++ b/packages/alsatian/core/maintenance/deprecate.ts
@@ -6,7 +6,7 @@ export function deprecate(
 	prompt: string
 ) {
 	Warner.warn(
-		`${featureName} has been depreacated and will be removed in version ${versionToBeRemoved}.` +
+		`${featureName} has been deprecated and will be removed in version ${versionToBeRemoved}.` +
 			(prompt ? ` ${prompt}` : "")
 	);
 }

--- a/packages/alsatian/test/integration-tests/expected-output/expectations/to-throw.txt
+++ b/packages/alsatian/test/integration-tests/expected-output/expectations/to-throw.txt
@@ -1,7 +1,7 @@
 TAP version 13
 1..16
 # FIXTURE error throwing
-# WARN: AsyncTest has been depreacated and will be removed in version 4.0.0. Use the Test decorator instead.
+# WARN: AsyncTest has been deprecated and will be removed in version 4.0.0. Use the Test decorator instead.
 ok 1 error throwing > errorThrown
 not ok 2 error throwing > errorNotThrown
  ---

--- a/packages/alsatian/test/integration-tests/expected-output/test-syntax/all-test-syntax.txt
+++ b/packages/alsatian/test/integration-tests/expected-output/test-syntax/all-test-syntax.txt
@@ -1,9 +1,9 @@
 TAP version 13
 1..16
 # FIXTURE asynchronous tests
-# WARN: AsyncTest has been depreacated and will be removed in version 4.0.0. Use the Test decorator instead.
-# WARN: AsyncSetup has been depreacated and will be removed in version 4.0.0. Use the Setup decorator instead.
-# WARN: AsyncTeardown has been depreacated and will be removed in version 4.0.0. Use the Teardown decorator instead.
+# WARN: AsyncTest has been deprecated and will be removed in version 4.0.0. Use the Test decorator instead.
+# WARN: AsyncSetup has been deprecated and will be removed in version 4.0.0. Use the Setup decorator instead.
+# WARN: AsyncTeardown has been deprecated and will be removed in version 4.0.0. Use the Teardown decorator instead.
 ok 1 asynchronous tests > simple passing asynchronous test
 not ok 2 asynchronous tests > simple failing asynchronous test
  ---

--- a/packages/alsatian/test/integration-tests/expected-output/test-syntax/async-test.txt
+++ b/packages/alsatian/test/integration-tests/expected-output/test-syntax/async-test.txt
@@ -1,7 +1,7 @@
 TAP version 13
 1..2
 # FIXTURE asynchronous tests
-# WARN: AsyncTest has been depreacated and will be removed in version 4.0.0. Use the Test decorator instead.
+# WARN: AsyncTest has been deprecated and will be removed in version 4.0.0. Use the Test decorator instead.
 ok 1 asynchronous tests > simple passing asynchronous test
 not ok 2 asynchronous tests > simple failing asynchronous test
  ---

--- a/packages/alsatian/test/integration-tests/expected-output/test-syntax/setup.txt
+++ b/packages/alsatian/test/integration-tests/expected-output/test-syntax/setup.txt
@@ -1,7 +1,7 @@
 TAP version 13
 1..3
 # FIXTURE setup tests
-# WARN: AsyncSetup has been depreacated and will be removed in version 4.0.0. Use the Setup decorator instead.
+# WARN: AsyncSetup has been deprecated and will be removed in version 4.0.0. Use the Setup decorator instead.
 ok 1 setup tests > simple setup
 ok 2 setup tests > simple async setup
 ok 3 setup tests > setup fixture only happened once

--- a/packages/alsatian/test/integration-tests/expected-output/test-syntax/teardown.txt
+++ b/packages/alsatian/test/integration-tests/expected-output/test-syntax/teardown.txt
@@ -1,7 +1,7 @@
 TAP version 13
 1..5
 # FIXTURE teardown fixtures
-# WARN: AsyncTeardown has been depreacated and will be removed in version 4.0.0. Use the Teardown decorator instead.
+# WARN: AsyncTeardown has been deprecated and will be removed in version 4.0.0. Use the Teardown decorator instead.
 ok 1 teardown fixtures > teardown fixture not called before first test
 ok 2 teardown fixtures > teardown fixture has still not been called after first test or before second
 # FIXTURE teardown tests

--- a/packages/alsatian/test/unit-tests/decorators/async-setup-decorator.spec.ts
+++ b/packages/alsatian/test/unit-tests/decorators/async-setup-decorator.spec.ts
@@ -82,7 +82,7 @@ export class AsyncSetupDecoratorTests {
 		AsyncSetup({}, "");
 
 		Expect(Warner.warn).toHaveBeenCalledWith(
-			"AsyncSetup has been depreacated and will be removed in version 4.0.0. " +
+			"AsyncSetup has been deprecated and will be removed in version 4.0.0. " +
 				"Use the Setup decorator instead."
 		);
 	}

--- a/packages/alsatian/test/unit-tests/decorators/async-setup-fixture.spec.ts
+++ b/packages/alsatian/test/unit-tests/decorators/async-setup-fixture.spec.ts
@@ -89,7 +89,7 @@ export class AsyncSetupFixtureDecoratorTests {
 		AsyncSetupFixture({}, "");
 
 		Expect(Warner.warn).toHaveBeenCalledWith(
-			"AsyncSetupFixture has been depreacated and will be removed in version 4.0.0. " +
+			"AsyncSetupFixture has been deprecated and will be removed in version 4.0.0. " +
 				"Use the SetupFixture decorator instead."
 		);
 	}

--- a/packages/alsatian/test/unit-tests/decorators/async-teardown-decorator.spec.ts
+++ b/packages/alsatian/test/unit-tests/decorators/async-teardown-decorator.spec.ts
@@ -82,7 +82,7 @@ export class AsyncTeardownDecoratorTests {
 		AsyncTeardown({}, "");
 
 		Expect(Warner.warn).toHaveBeenCalledWith(
-			"AsyncTeardown has been depreacated and will be removed in version 4.0.0. " +
+			"AsyncTeardown has been deprecated and will be removed in version 4.0.0. " +
 				"Use the Teardown decorator instead."
 		);
 	}

--- a/packages/alsatian/test/unit-tests/decorators/async-teardown-fixture.spec.ts
+++ b/packages/alsatian/test/unit-tests/decorators/async-teardown-fixture.spec.ts
@@ -91,7 +91,7 @@ export class AsyncTeadownFixtureDecoratorTests {
 		AsyncTeardownFixture({}, "");
 
 		Expect(Warner.warn).toHaveBeenCalledWith(
-			"AsyncTeardownFixture has been depreacated and will be removed in version 4.0.0. " +
+			"AsyncTeardownFixture has been deprecated and will be removed in version 4.0.0. " +
 				"Use the TeardownFixture decorator instead."
 		);
 	}

--- a/packages/alsatian/test/unit-tests/decorators/async-test-decorator.spec.ts
+++ b/packages/alsatian/test/unit-tests/decorators/async-test-decorator.spec.ts
@@ -108,7 +108,7 @@ export class AsyncTestDecoratorTests {
 		AsyncTestDecorator("")({}, "");
 
 		Expect(Warner.warn).toHaveBeenCalledWith(
-			"AsyncTest has been depreacated and will be removed in version 4.0.0. " +
+			"AsyncTest has been deprecated and will be removed in version 4.0.0. " +
 				"Use the Test decorator instead."
 		);
 	}

--- a/packages/alsatian/test/unit-tests/decorators/focus-test.spec.ts
+++ b/packages/alsatian/test/unit-tests/decorators/focus-test.spec.ts
@@ -30,7 +30,7 @@ export class FocusTestDecoratorTests {
 		FocusTestDecorator({}, "");
 
 		Expect(Warner.warn).toHaveBeenCalledWith(
-			"FocusTest has been depreacated and will be removed in version 4.0.0. " +
+			"FocusTest has been deprecated and will be removed in version 4.0.0. " +
 				"Use the Focus decorator instead."
 		);
 	}

--- a/packages/alsatian/test/unit-tests/decorators/focus-tests.spec.ts
+++ b/packages/alsatian/test/unit-tests/decorators/focus-tests.spec.ts
@@ -30,7 +30,7 @@ export class FocusTestsDecoratorTests {
 		FocusTestsDecorator(TestFixtureClass);
 
 		Expect(Warner.warn).toHaveBeenCalledWith(
-			"FocusTests has been depreacated and will be removed in version 4.0.0. " +
+			"FocusTests has been deprecated and will be removed in version 4.0.0. " +
 				"Use the Focus decorator instead."
 		);
 	}

--- a/packages/alsatian/test/unit-tests/decorators/ignore-test.spec.ts
+++ b/packages/alsatian/test/unit-tests/decorators/ignore-test.spec.ts
@@ -47,7 +47,7 @@ export class IgnoreTestDecoratorTests {
 		IgnoreTestDecorator("")({}, "");
 
 		Expect(Warner.warn).toHaveBeenCalledWith(
-			"IgnoreTest has been depreacated and will be removed in version 4.0.0. " +
+			"IgnoreTest has been deprecated and will be removed in version 4.0.0. " +
 				"Use the Ignore decorator instead."
 		);
 	}

--- a/packages/alsatian/test/unit-tests/decorators/ignore-tests.spec.ts
+++ b/packages/alsatian/test/unit-tests/decorators/ignore-tests.spec.ts
@@ -44,7 +44,7 @@ export class IgnoreTestsDecoratorTests {
 		IgnoreTestsDecorator("");
 
 		Expect(Warner.warn).toHaveBeenCalledWith(
-			"IgnoreTests has been depreacated and will be removed in version 4.0.0. " +
+			"IgnoreTests has been deprecated and will be removed in version 4.0.0. " +
 				"Use the Ignore decorator instead."
 		);
 	}


### PR DESCRIPTION
# Description
Correct typo "depreacated" => "deprecated"

# Checklist

- [x] I am an awesome developer and proud of my code
- [x] I added / updated / removed relevant unit or integration tests to prove my change works
- [ ] I ran all tests using ```npm test``` to make sure everything else still works
- [ ] I ran ```npm run review``` to ensure the code adheres to the repository standards

I tried to run the tests, but they failed on my machine (also it seems that they are failing on the build server, even though is says that the build is passing). I tried to run `npm run review`, but the `review` script does not exists as far as I can tell.