### PR TITLE
Overload createFunctionSpy to allow passing function type

### DIFF
--- a/packages/alsatian/core/alsatian-core.ts
+++ b/packages/alsatian/core/alsatian-core.ts
@@ -91,6 +91,7 @@ export {
 	PropertyMatcher,
 	Setup,
 	SetupFixture,
+	ISpiedFunction,
 	FunctionSpy,
 	RestorableFunctionSpy,
 	createFunctionSpy,

--- a/packages/alsatian/core/spying/create-function-spy.ts
+++ b/packages/alsatian/core/spying/create-function-spy.ts
@@ -1,13 +1,13 @@
 import { FunctionSpy } from "./function-spy";
 import { exposeSpyFunctions } from "./expose-spy-functions";
-import { ISpiedFunction } from "./spied-function.i";
+import { ISpiedFunction, TypedFunction } from "./spied-function.i";
 
-export function createFunctionSpy<FunctionType extends (...args: Array<any>) => any>(): FunctionType & FunctionSpy;
-export function createFunctionSpy<ArgumentType, ReturnType>(): ISpiedFunction<ArgumentType, ReturnType>;
-export function createFunctionSpy<ArgumentType, ReturnType>(): ISpiedFunction<
+export function createFunctionSpy<FunctionType extends TypedFunction>(): ISpiedFunction<FunctionType>;
+export function createFunctionSpy<
 	ArgumentType,
 	ReturnType
-> {
+>(): ISpiedFunction<(...args: Array<ArgumentType>) => ReturnType>;
+export function createFunctionSpy() {
 	const functionSpy = new FunctionSpy();
 
 	const spiedFunction = functionSpy.call.bind(functionSpy);

--- a/packages/alsatian/core/spying/create-function-spy.ts
+++ b/packages/alsatian/core/spying/create-function-spy.ts
@@ -2,6 +2,8 @@ import { FunctionSpy } from "./function-spy";
 import { exposeSpyFunctions } from "./expose-spy-functions";
 import { ISpiedFunction } from "./spied-function.i";
 
+export function createFunctionSpy<FunctionType extends (...args: Array<any>) => any>(): FunctionType & FunctionSpy;
+export function createFunctionSpy<ArgumentType, ReturnType>(): ISpiedFunction<ArgumentType, ReturnType>;
 export function createFunctionSpy<ArgumentType, ReturnType>(): ISpiedFunction<
 	ArgumentType,
 	ReturnType

--- a/packages/alsatian/core/spying/expose-spy-functions.ts
+++ b/packages/alsatian/core/spying/expose-spy-functions.ts
@@ -1,8 +1,8 @@
 import { FunctionSpy } from "./function-spy";
-import { ISpiedFunction } from "./spied-function.i";
+import { ISpiedFunction, TypedFunction } from "./spied-function.i";
 
-export function exposeSpyFunctions<ArgumentType, ReturnType>(
-	spiedFunction: ISpiedFunction<ArgumentType, ReturnType>,
+export function exposeSpyFunctions<T extends TypedFunction>(
+	spiedFunction: ISpiedFunction<T>,
 	functionSpy: FunctionSpy
 ) {
 	// expose spy's calls on function

--- a/packages/alsatian/core/spying/spied-function.i.ts
+++ b/packages/alsatian/core/spying/spied-function.i.ts
@@ -1,14 +1,5 @@
 import { FunctionSpy } from "./function-spy";
 
-export type TypedFunction<ArgumentType, ReturnType> = (
-	...args: Array<ArgumentType>
-) => ReturnType;
+export type TypedFunction = (...args: Array<any>) => any;
 
-export interface ISpiedFunction<ArgumentType, ReturnType>
-	extends TypedFunction<ArgumentType, ReturnType>,
-		FunctionSpy {
-	call: (
-		thisArg: any,
-		...functionArguments: Array<ArgumentType>
-	) => ReturnType;
-}
+export type ISpiedFunction<T extends TypedFunction> = T & FunctionSpy;


### PR DESCRIPTION
# Description

This allows you to pass just 1 generic argument to createFunctionSpy in the form of a function type - this solves the problem of having multiple arguments too.

```ts
type MyFunction = <TReturn>(arg1: number, arg2: string) => TReturn;

const spy1 = createFunctionSpy<(foo: boolean, bar: string) => number>();
const spy2 = createFunctionSpy<MyFunction<string>>();
```

# Checklist

- [x] I am an awesome developer and proud of my code
- [ ] I added / updated / removed relevant unit or integration tests to prove my change works
- [x] I ran all tests using ```npm test``` to make sure everything else still works

Not sure I need to update any tests here since this is just a typing change