### PR TITLE
Resolving test appearing to run forever on error

### DIFF
--- a/packages/vscode-extension/src/commands/debug-test-command.ts
+++ b/packages/vscode-extension/src/commands/debug-test-command.ts
@@ -5,10 +5,10 @@ import { RunTestCommand } from "./run-test-command";
 export class DebugTestCommand extends AlsatianCommand {
     protected static commandName = "debugTest";
     public static title = "$(debug) Debug";
-    
+
     public static async execute(fileName: string, fixtureName: string, testName: string, range: Range) {
         const debuggerPort = 40894;
-        
+
         debug.startDebugging(
             undefined,
             {

--- a/packages/vscode-extension/src/run.ts
+++ b/packages/vscode-extension/src/run.ts
@@ -26,7 +26,7 @@ function sendMessage<T extends IMessage | string>(message: T) {
 
         if (alsatianConfigPath) {
             const alsatianConfig = await import(alsatianConfigPath);
-            
+
             const root = alsatianConfigPath.split(/[\\/]/);
             root.pop();
             const rootPath = root.join("/");
@@ -36,9 +36,9 @@ function sendMessage<T extends IMessage | string>(message: T) {
                 join(rootPath, alsatianConfig.tsconfig) :
                 await findNearestFile("tsconfig.json", fileName)
             );
-    
+
             const preTestScripts = ((alsatianConfig.preTestScripts || []) as string[]).map(script => join(rootPath, script));
-    
+
             await Promise.all(preTestScripts.map(script => import(script)));
         }
         else {
@@ -49,7 +49,7 @@ function sendMessage<T extends IMessage | string>(message: T) {
 
         testSet.addTestsFromFiles(fileName);
 
-        const fixture = testSet.testFixtures.filter(x => x.fixture.constructor.name === fixtureName)[0];    
+        const fixture = testSet.testFixtures.filter(x => x.fixture.constructor.name === fixtureName)[0];
         fixture.focussed = true;
 
         if (testName) {
@@ -75,7 +75,7 @@ function sendMessage<T extends IMessage | string>(message: T) {
             results: results.map(x => ({ outcome: x.outcome, error: x.error ? { message: x.error?.message }: null }))
         });
     }
-    catch (error) {        
+    catch (error) {
         sendMessage(`error running test ${error}`);
         sendMessage({
             type: MessageType.RunComplete,

--- a/packages/vscode-extension/src/running/test-runner.ts
+++ b/packages/vscode-extension/src/running/test-runner.ts
@@ -32,7 +32,7 @@ export class TestRunner {
         }
 
         const runProcess = fork(join(__dirname, `../run`), runArguments, { execArgv });
-    
+
         const results = await new Promise<ITestCompleteEvent[] | null>((resolve, reject) => {
             let results = [] as ITestCompleteEvent[];
 
@@ -56,8 +56,16 @@ export class TestRunner {
                     output.appendLine(message);
                 }
             });
-    
+
             runProcess.on("exit", code => {
+                if (code !== null && code > 0) {
+                    this.resultEmitter.fire({
+                        type: ResultEventType.Error,
+                        payload: {
+                            ...eventData
+                        }
+                    });
+                }
                 resolve(null);
             });
         });
@@ -87,5 +95,6 @@ export interface TestResultEvent {
 export enum ResultEventType {
     Started = "STARTED",
     TestCompleted = "TEST_COMPLETED",
-    RunCompleted = "RUN_COMPLETED"
+    RunCompleted = "RUN_COMPLETED",
+    Error = "ERROR"
 }


### PR DESCRIPTION
<!-- Hey, there! Thanks for contributing to Alsatian,
      Add a quick description of the changes you have made below -->

# Description
When using the vscode extension in some cases you would run your tests and it would look like your tests were being executed, this did not change in certain scenarios when an error had actually occured


<!-- Now, we've created a handy checklist before submitting your pull request to ensure it goes smoothly
      (we checked the first one for you because we know it's true) -->

# Checklist

- [x] I am an awesome developer and proud of my code
- [ ] I added / updated / removed relevant unit or integration tests to prove my change works
- [ ] I ran all tests using ```npm test``` to make sure everything else still works

<!-- Thanks again, and if you'd like to add any further information you can do so below -->

# Additional Information
